### PR TITLE
OPENEUROPA-1329: Creating AV Portal mock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@
 
 Media AV Portal adds the [European Audiovisual Services](http://ec.europa.eu/avservices/) as a supported media provider.
 
+# Mock service
+
+The project also comes with a test module that provides a mock to the remote AV Portal service. Meaning that tests do not have to be run against the remote service.
+
+## How to use the mock
+
+Enable the `media_avportal_mock` inside a given test and all HTTP requests going to AV Portal API will be intercepted automatically. These, then, will return predefined responses that can be inspected in the `responses` folder of the mock module.
+
+By default, there are 3 types of requests that are mocked:
+
+* A default request with no options
+* A request for a given resource (the options contain the `ref` key)
+* A request that searches for a given term (the options contain the `kwand` key)
+
+Additionally, any request to a resource thumbnail will return a local thumbnail image.
+
+## Extending the mock
+
+If another module needs to test interactions that require more responses, these can be provided via an event subscriber (to the `AvPortalMockEvent` event).
+
+In the subscriber, 3 types of responses (in JSON format) can be provided:
+
+* Individual resources
+* Search results for a given term
+* A default response to replace the existing one
+
+As an example, you can see the subscriber that provides the default resources, `AvPortalMockEventSubscriber`.
+
 **Table of contents:**
 
 - [Installation](#installation)

--- a/src/AvPortalClient.php
+++ b/src/AvPortalClient.php
@@ -44,7 +44,7 @@ class AvPortalClient implements AvPortalClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function query(array $options): ?array {
+  public function query(array $options = []): ?array {
     $options += [
       'fl' => 'type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json',
       'hasmedia' => 1,

--- a/tests/modules/media_avportal_mock/media_avportal_mock.info.yml
+++ b/tests/modules/media_avportal_mock/media_avportal_mock.info.yml
@@ -1,0 +1,4 @@
+name: Media AV Portal Mock
+description: Provides a middleware for the returning mocked responses from AV Portal. Do not use this in production.
+core: 8.x
+type: module

--- a/tests/modules/media_avportal_mock/media_avportal_mock.services.yml
+++ b/tests/modules/media_avportal_mock/media_avportal_mock.services.yml
@@ -1,0 +1,10 @@
+services:
+  media_avportal_mock.client_middleware:
+    class: Drupal\media_avportal_mock\AvPortalClientMiddleware
+    arguments: ['@config.factory', '@event_dispatcher']
+    tags:
+      - { name: http_client_middleware }
+  media_avportal_mock.event_subscriber:
+    class: Drupal\media_avportal_mock\EventSubscriber\AvPortalMockEventSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/tests/modules/media_avportal_mock/responses/default.json
+++ b/tests/modules/media_avportal_mock/responses/default.json
@@ -1,0 +1,243 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 29,
+    "params": {
+      "pagesize": "15",
+      "index": "1",
+      "hasmedia": "1",
+      "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
+      "proxy": "true",
+      "serverName": "wlpc0099",
+      "type": "VIDEO",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 15,
+    "start": 0,
+    "docs": [
+      {
+        "ref": "I-163595",
+        "duration": "944.8",
+        "titles_json": {
+          "FR": " ",
+          "EN": " "
+        },
+        "summary_json": {
+          "FR": " ESA - Student orbital project",
+          "EN": " ESA - Student orbital project"
+        },
+        "shootstartdate": "20181116 07:30",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "TEXT": "English",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "EN": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/THUMB_M_I163595INT1W_6.jpg?latest=0006674278",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/MP3_I163595EN1W.mp3?latest=0006674282",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/THUMB_I163595INT1W_6.jpg?latest=0006674276",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/LR_I163595EN1W.mp4?latest=0006674280"
+            },
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/THUMB_M_I163595INT1W_6.jpg?latest=0006672590",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/THUMB_I163595INT1W_6.jpg?latest=0006672588",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163595\/LR_I163595INT1W.mp4?latest=0006672592"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163308",
+        "duration": "",
+        "titles_json": {
+          "FR": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
+          "EN": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
+        },
+        "summary_json": {
+          "FR": "  - Welcome to the political segment by Gernot BLÜMEL, Austrian Federal Minister for the EU, Arts, Culture and Media - Keynote speech by  Frans TIMMERMANS, First Vice-President of the EC in charge of Better Regulation, Inter-Institutional Relations, the Rule of Law and the Charter of Fundamental Rights, and Chairman of the Task Force on Subsidiarity, Proportionality and \"Doing Less More Efficiently\" - Interviews Melania-Gabriela CIOT, Romania Secretary of State for European Affairs at the Ministry of Foreign Affairs Karl-Heinz LAMBERTZ, President of the Committee of the Regions Markus WALLNER, Landeshauptmann of Vorarlberg",
+          "EN": "  - Welcome to the political segment by Gernot BLÜMEL, Austrian Federal Minister for the EU, Arts, Culture and Media - Keynote speech by  Frans TIMMERMANS, First Vice-President of the EC in charge of Better Regulation, Inter-Institutional Relations, the Rule of Law and the Charter of Fundamental Rights, and Chairman of the Task Force on Subsidiarity, Proportionality and \"Doing Less More Efficiently\" - Interviews Melania-Gabriela CIOT, Romania Secretary of State for European Affairs at the Ministry of Foreign Affairs Karl-Heinz LAMBERTZ, President of the Committee of the Regions Markus WALLNER, Landeshauptmann of Vorarlberg"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163707",
+        "duration": "",
+        "titles_json": {
+          "FR": " Arrivals and doorsteps",
+          "EN": " Arrivals and doorsteps"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163706",
+        "duration": "",
+        "titles_json": {
+          "FR": " LIVE Economic and Financial Affairs Council (Budget) - Arrivals",
+          "EN": " LIVE Economic and Financial Affairs Council (Budget) - Arrivals"
+        },
+        "summary_json": {
+          "FR": " Arrivals and doorsteps",
+          "EN": " Arrivals and doorsteps"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163331",
+        "duration": "",
+        "titles_json": {
+          "FR": " LIVE Economic and Financial Affairs Council (Budget) - Arrivals",
+          "EN": " LIVE Economic and Financial Affairs Council (Budget) - Arrivals"
+        },
+        "summary_json": {
+          "FR": " Start of the arrivals ",
+          "EN": " Start of the arrivals "
+        },
+        "shootstartdate": "20181116 08:59",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163692",
+        "duration": "",
+        "titles_json": {
+          "FR": " Arrivals and doorsteps",
+          "EN": " Arrivals and doorsteps"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163694",
+        "duration": "",
+        "titles_json": {
+          "FR": " Donald TUSK, President of the European Council, receives Sebastian KURZ, Austrian Federal Chancellor:",
+          "EN": " Donald TUSK, President of the European Council, receives Sebastian KURZ, Austrian Federal Chancellor:"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163337",
+        "duration": "",
+        "titles_json": {
+          "FR": " Economic and Financial Affairs Council (Budget) - Press conference by the Austrian Presidency and the European Commission",
+          "EN": " Economic and Financial Affairs Council (Budget) - Press conference by the Austrian Presidency and the European Commission"
+        },
+        "summary_json": {
+          "FR": " Press conference opening remarks by the European Commission",
+          "EN": " Press conference opening remarks by the European Commission"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163601",
+        "duration": "",
+        "titles_json": {
+          "FR": " Commissioner Johannes HAHN in Tunis, Tunisia",
+          "EN": " Commissioner Johannes HAHN in Tunis, Tunisia"
+        },
+        "summary_json": {
+          "FR": " \"Rethinking the Euro-Mediterranean cultural partnership\" Conference The Mediterranean in the 21st century - Opening speech by  Johannes HAHN, Member of the EC in charge of European Neighbourhood Policy and Enlargement Negotiations",
+          "EN": " \"Rethinking the Euro-Mediterranean cultural partnership\" Conference The Mediterranean in the 21st century - Opening speech by  Johannes HAHN, Member of the EC in charge of European Neighbourhood Policy and Enlargement Negotiations"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163339",
+        "duration": "",
+        "titles_json": {
+          "FR": " Economic and Financial Affairs Council (Budget) - Press conference by the Austrian Presidency and the European Commission",
+          "EN": " Economic and Financial Affairs Council (Budget) - Press conference by the Austrian Presidency and the European Commission"
+        },
+        "summary_json": {
+          "FR": " Recorded cutaways",
+          "EN": " Recorded cutaways"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163665",
+        "duration": "",
+        "titles_json": {
+          "FR": " STOCKSHOTS EP",
+          "EN": " STOCKSHOTS EP"
+        },
+        "summary_json": {
+          "FR": " United Kingdom and the European Parliament: updated version",
+          "EN": " United Kingdom and the European Parliament: updated version"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163333",
+        "duration": "",
+        "titles_json": {
+          "FR": " Economic and Financial Affairs Council (Budget): - all non-doorsteps arrivals",
+          "EN": " Economic and Financial Affairs Council (Budget): - all non-doorsteps arrivals"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163454",
+        "duration": "",
+        "titles_json": {
+          "FR": "  Jean-Claude JUNCKER, President of the EC, receives Arno KOMPATSCHER, Landeshauptmann of the Autonomous Province of Bolzano \u2013 South Tyrol:",
+          "EN": "  Jean-Claude JUNCKER, President of the EC, receives Arno KOMPATSCHER, Landeshauptmann of the Autonomous Province of Bolzano \u2013 South Tyrol:"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163329",
+        "duration": "",
+        "titles_json": {
+          "FR": " EC Midday press briefing of 16\/11\/2018",
+          "EN": " EC Midday press briefing of 16\/11\/2018"
+        },
+        "summary_json": {
+          "FR": " Recorded cutaways:",
+          "EN": " Recorded cutaways:"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163693",
+        "duration": "",
+        "titles_json": {
+          "FR": " Announcements:",
+          "EN": " Announcements:"
+        },
+        "shootstartdate": "20181116 00:00",
+        "type": "VIDEO"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/resources/I-162747.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-162747.json
@@ -1,0 +1,89 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 14,
+    "params": {
+      "pagesize": "15",
+      "ref": "I-162747",
+      "index": "1",
+      "hasmedia": "1",
+      "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
+      "proxy": "true",
+      "serverName": "wlpc0099",
+      "type": "VIDEO",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "docs": [
+      {
+        "ref": "I-162747",
+        "duration": "85.9",
+        "titles_json": {
+          "FR": "Point de presse de la mi-journée du 25\/10\/2018",
+          "EN": "Midday press briefing from 25\/10\/2018"
+        },
+        "summary_json": {
+          "FR": "During today's EC midday press briefing, this topic has been touched on:<br>COMMISSION - EC President Juncker phone call with Chancellor Merkel: - Q&A ",
+          "EN": "During today's EC midday press briefing, this topic has been touched on:<br>COMMISSION - EC President Juncker phone call with Chancellor Merkel: - Q&A "
+        },
+        "shootstartdate": "20181025 12:17",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "TEXT": "English",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "FR": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Français",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "FR": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/THUMB_M_I162747INT1W_05.jpg?latest=0006614044",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/MP3_I162747FR1W.mp3?latest=0006614048",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/THUMB_I162747INT1W_05.jpg?latest=0006614042",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/LR_I162747FR1W.mp4?latest=0006614046"
+            },
+            "EN": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/THUMB_M_I162747INT1W_05.jpg?latest=0006614034",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/MP3_I162747EN1W.mp3?latest=0006614038",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/THUMB_I162747INT1W_05.jpg?latest=0006614032",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/LR_I162747EN1W.mp4?latest=0006614036"
+            },
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/THUMB_M_I162747INT1W_05.jpg?latest=0006614330",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/HD_I162747INT1W.mp4?latest=0006614336",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/MP3_I162747INT1W.mp3?latest=0006614334",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/THUMB_I162747INT1W_05.jpg?latest=0006614328",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/162747\/LR_I162747INT1W.mp4?latest=0006614332"
+            }
+          }
+        },
+        "type": "VIDEO"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/resources/I-163162.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-163162.json
@@ -1,0 +1,59 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 20,
+    "params": {
+      "pagesize": "15",
+      "ref": "I-163162",
+      "index": "1",
+      "hasmedia": "1",
+      "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
+      "proxy": "true",
+      "serverName": "wlpc0099",
+      "type": "VIDEO",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "docs": [
+      {
+        "ref": "I-163162",
+        "duration": "0",
+        "titles_json": {
+          "FR": " Economic and Financial Affairs Council - Arrivals",
+          "EN": " Economic and Financial Affairs Council - Arrivals"
+        },
+        "summary_json": {
+          "FR": " Start of the arrivals",
+          "EN": " Start of the arrivals"
+        },
+        "shootstartdate": "20181106 08:12",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/02\/163162\/THUMB_M_I163162INT1W_04.jpg?latest=0006625964",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/02\/163162\/HD_I163162INT1W.mp4?latest=0006625970",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/02\/163162\/MP3_I163162INT1W.mp3?latest=0006625968",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/02\/163162\/THUMB_I163162INT1W_04.jpg?latest=0006625962",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/02\/163162\/LR_I163162INT1W.mp4?latest=0006625966"
+            }
+          }
+        },
+        "type": "VIDEO"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/resources/not-found.json
+++ b/tests/modules/media_avportal_mock/responses/resources/not-found.json
@@ -1,0 +1,22 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 21,
+    "params": {
+      "pagesize": "15",
+      "ref": "I-12345678987654321",
+      "index": "1",
+      "hasmedia": "1",
+      "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
+      "proxy": "true",
+      "serverName": "wlpc0100",
+      "type": "VIDEO",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 0,
+    "start": 0,
+    "docs": []
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/searches/empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/empty.json
@@ -1,0 +1,23 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 21,
+    "params": {
+      "pagesize": "15",
+      "ref": "I-12345678987654321",
+      "index": "1",
+      "hasmedia": "1",
+      "kwand": "",
+      "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
+      "proxy": "true",
+      "serverName": "wlpc0100",
+      "type": "VIDEO",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 0,
+    "start": 0,
+    "docs": []
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/searches/europe.json
+++ b/tests/modules/media_avportal_mock/responses/searches/europe.json
@@ -1,0 +1,1070 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 25,
+    "params": {
+      "pagesize": "15",
+      "index": "1",
+      "hasmedia": "1",
+      "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
+      "kwand": "europe",
+      "proxy": "true",
+      "serverName": "wlpc0099",
+      "type": "VIDEO",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 15,
+    "start": 0,
+    "docs": [
+      {
+        "ref": "I-163675",
+        "duration": "",
+        "titles_json": {
+          "FR": " Start-up Europe Award Ceremony",
+          "EN": " Start-up Europe Award Ceremony"
+        },
+        "shootstartdate": "20181115 00:00",
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163634",
+        "duration": "269",
+        "titles_json": {
+          "FR": " EDIT \/ RECORDED Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2",
+          "EN": " EDIT \/ RECORDED Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2"
+        },
+        "summary_json": {
+          "FR": " Start-up Europe Summit - Start-up Europe Award Ceremony",
+          "EN": " Start-up Europe Summit - Start-up Europe Award Ceremony"
+        },
+        "shootstartdate": "20181115 00:00",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/14\/163634\/THUMB_M_I163634INT1W_5.jpg?latest=0006673870",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/14\/163634\/HD_I163634INT1W.mp4?latest=0006673876",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/14\/163634\/MP3_I163634INT1W.mp3?latest=0006673874",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/14\/163634\/THUMB_I163634INT1W_5.jpg?latest=0006673868",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/14\/163634\/LR_I163634INT1W.mp4?latest=0006673872"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163655",
+        "duration": "434.7",
+        "titles_json": {
+          "FR": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2",
+          "EN": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2"
+        },
+        "summary_json": {
+          "FR": " Start-up Europe Summit - Press point by Mariya GABRIEL, Member of the EC in charge of Digital Economy and Society",
+          "EN": " Start-up Europe Summit - Press point by Mariya GABRIEL, Member of the EC in charge of Digital Economy and Society"
+        },
+        "shootstartdate": "20181115 15:09",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163655\/THUMB_M_I163655INT1W_8.jpg?latest=0006673738",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163655\/HD_I163655INT1W.mp4?latest=0006673744",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163655\/MP3_I163655INT1W.mp3?latest=0006673742",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163655\/THUMB_I163655INT1W_8.jpg?latest=0006673736",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163655\/LR_I163655INT1W.mp4?latest=0006673740"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163635",
+        "duration": "139.9",
+        "titles_json": {
+          "FR": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2",
+          "EN": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2"
+        },
+        "summary_json": {
+          "FR": " Start-up Europe Summit - Signing Ceremony of the Joint Declaration on Reinforcing the CEE & Western Balkans Tech Entrepreneurship Ecosystems ",
+          "EN": " Start-up Europe Summit - Signing Ceremony of the Joint Declaration on Reinforcing the CEE & Western Balkans Tech Entrepreneurship Ecosystems "
+        },
+        "shootstartdate": "20181115 15:07",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163635\/THUMB_M_I163635INT1W_8.jpg?latest=0006672610",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163635\/HD_I163635INT1W.mp4?latest=0006672616",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163635\/MP3_I163635INT1W.mp3?latest=0006672614",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163635\/THUMB_I163635INT1W_8.jpg?latest=0006672608",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/15\/163635\/LR_I163635INT1W.mp4?latest=0006672612"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163600",
+        "duration": "1346.8",
+        "titles_json": {
+          "FR": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2",
+          "EN": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 1\/2"
+        },
+        "summary_json": {
+          "FR": " Start-up Europe Summit - keynote by  Mariya GABRIEL, Member of the EC in charge of Digital Economy and Society",
+          "EN": " Start-up Europe Summit - keynote by  Mariya GABRIEL, Member of the EC in charge of Digital Economy and Society"
+        },
+        "shootstartdate": "20181115 14:45",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/00\/163600\/THUMB_M_I163600INT1W_04.jpg?latest=0006674204",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/00\/163600\/HD_I163600INT1W.mp4?latest=0006674210",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/00\/163600\/MP3_I163600INT1W.mp3?latest=0006674208",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/00\/163600\/THUMB_I163600INT1W_04.jpg?latest=0006674202",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/00\/163600\/LR_I163600INT1W.mp4?latest=0006674206"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163636",
+        "duration": "803.3",
+        "titles_json": {
+          "FR": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 2\/2",
+          "EN": " Commissioner Mariya GABRIEL in Sofia, Bulgaria 2\/2"
+        },
+        "summary_json": {
+          "FR": " Start-up Europe Summit - Closing remarks by Tomislav DONCHEV, Bulgarian Vice Prime Minister, and Mariya GABRIEL, Member of the EC in charge of Digital Economy and Society ",
+          "EN": " Start-up Europe Summit - Closing remarks by Tomislav DONCHEV, Bulgarian Vice Prime Minister, and Mariya GABRIEL, Member of the EC in charge of Digital Economy and Society "
+        },
+        "shootstartdate": "20181115 17:00",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/16\/163636\/THUMB_M_I163636INT1W_6.jpg?latest=0006674192",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/16\/163636\/HD_I163636INT1W.mp4?latest=0006674198",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/16\/163636\/MP3_I163636INT1W.mp3?latest=0006674196",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/16\/163636\/THUMB_I163636INT1W_6.jpg?latest=0006674190",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/16\/163636\/LR_I163636INT1W.mp4?latest=0006674194"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163385",
+        "duration": "247.8",
+        "titles_json": {
+          "FR": " Press conference on launch of the new website \" WHAT EUROPE DOES FOR ME\" : - extracts from the press conference",
+          "EN": " Press conference on launch of the new website \" WHAT EUROPE DOES FOR ME\" : - extracts from the press conference"
+        },
+        "shootstartdate": "20181114 13:45",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163385\/THUMB_M_I163385INT1W_2.jpg?latest=0006660372",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163385\/HD_I163385INT1W.mp4?latest=0006660378",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163385\/MP3_I163385INT1W.mp3?latest=0006660376",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163385\/THUMB_I163385INT1W_2.jpg?latest=0006660370",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163385\/LR_I163385INT1W.mp4?latest=0006660374"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163290",
+        "duration": "0",
+        "titles_json": {
+          "FR": " LIVE EP press conference Launch of the new website \" WHAT EUROPE DOES FOR ME\"",
+          "EN": " LIVE EP press conference Launch of the new website \" WHAT EUROPE DOES FOR ME\""
+        },
+        "summary_json": {
+          "FR": " Press conference by Antonio TAJANI, EP President",
+          "EN": " Press conference by Antonio TAJANI, EP President"
+        },
+        "shootstartdate": "20181114 10:09",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "TEXT": "English",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "FR": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Français",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "DE": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Deutsch",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "IT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Italiano",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "ES": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Espanol",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Ελληνικά",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "PL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Polski",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "PL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657490",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657488",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290PL1W.mp4?latest=0006657492"
+            },
+            "FR": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657450",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657448",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290FR1W.mp4?latest=0006657452"
+            },
+            "EN": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657430",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657428",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290EN1W.mp4?latest=0006657432"
+            },
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657462",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/HD_I163290INT1W.mp4?latest=0006657470",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657458",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290INT1W.mp4?latest=0006657464"
+            },
+            "ES": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657440",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657438",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290ES1W.mp4?latest=0006657442"
+            },
+            "DE": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657420",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657418",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290DE1W.mp4?latest=0006657422"
+            },
+            "IT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006657480",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006657478",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290IT1W.mp4?latest=0006657482"
+            },
+            "EL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_M_I163290INT1W_08.jpg?latest=0006659549",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/THUMB_I163290INT1W_08.jpg?latest=0006659547",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163290\/LR_I163290EL1W.mp4?latest=0006659551"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163299",
+        "duration": "2515.3",
+        "titles_json": {
+          "FR": " Crisis group's 2018 Watch List Policy Dialogue Day",
+          "EN": " Crisis group's 2018 Watch List Policy Dialogue Day"
+        },
+        "summary_json": {
+          "FR": " Session I Plenary - The EU as a Global peace actor Speakers - Federica MOGHERINI, High Representative of the Union for Foreign Affairs and Security Policy and Vice-President of the EC - Robert MALLEY, President and CEO at the International Crisis Group Moderator Rosa BALFOUR, Senior Fellow, Europe program, The German Marshall Fund of the United States",
+          "EN": " Session I Plenary - The EU as a Global peace actor Speakers - Federica MOGHERINI, High Representative of the Union for Foreign Affairs and Security Policy and Vice-President of the EC - Robert MALLEY, President and CEO at the International Crisis Group Moderator Rosa BALFOUR, Senior Fellow, Europe program, The German Marshall Fund of the United States"
+        },
+        "shootstartdate": "20181114 12:55",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/19\/163299\/THUMB_M_I163299INT1W_8.jpg?latest=0006659683",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/19\/163299\/HD_I163299INT1W.mp4?latest=0006659689",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/19\/163299\/MP3_I163299INT1W.mp3?latest=0006659687",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/19\/163299\/THUMB_I163299INT1W_8.jpg?latest=0006659681",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/19\/163299\/LR_I163299INT1W.mp4?latest=0006659685"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-162933",
+        "duration": "1622.1",
+        "titles_json": {
+          "FR": " LIVE EP Plenary session Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe ",
+          "EN": " LIVE EP Plenary session Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe "
+        },
+        "summary_json": {
+          "FR": " Opening statement by Angela MERKEL, Chancellor of Germany on the Future of Europe ",
+          "EN": " Opening statement by Angela MERKEL, Chancellor of Germany on the Future of Europe "
+        },
+        "shootstartdate": "20181113 00:00",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "TEXT": "English",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "FR": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Français",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "DE": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Deutsch",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "IT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Italiano",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "ES": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Espanol",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Ελληνικά",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "PT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Português",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "NL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Nederlands",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "DA": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Dansk",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "FI": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Suomi",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "SV": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Svenska",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "CS": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Čeština",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "ET": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Eesti",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "LV": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Latviešu",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "LT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Lietuvių",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "HU": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Magyar",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "MT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Malti",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "PL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Polski",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "SK": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Slovenčina",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "SL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Slovenščina",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "BG": {
+              "SUPPORTS": "WEB",
+              "TEXT": "български",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "RO": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Română",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "HR": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Hrvatski",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "LV": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649680",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933LV1W.mp3?latest=0006649684",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649678",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933LV1W.mp4?latest=0006649682"
+            },
+            "LT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649670",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933LT1W.mp3?latest=0006649674",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649668",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933LT1W.mp4?latest=0006649672"
+            },
+            "CS": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649400",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933CS1W.mp3?latest=0006649404",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649398",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933CS1W.mp4?latest=0006649402"
+            },
+            "HR": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649832",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933HR1W.mp3?latest=0006649838",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649828",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933HR1W.mp4?latest=0006649834"
+            },
+            "SL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649860",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933SL1W.mp3?latest=0006649864",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649858",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933SL1W.mp4?latest=0006649862"
+            },
+            "SK": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649712",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933SK1W.mp3?latest=0006649718",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649708",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933SK1W.mp4?latest=0006649714"
+            },
+            "DA": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649412",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933DA1W.mp3?latest=0006649418",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649408",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933DA1W.mp4?latest=0006649414"
+            },
+            "RO": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649850",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933RO1W.mp3?latest=0006649854",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649848",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933RO1W.mp4?latest=0006649852"
+            },
+            "IT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649510",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933IT1W.mp3?latest=0006649514",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649508",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933IT1W.mp4?latest=0006649512"
+            },
+            "MT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649690",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933MT1W.mp3?latest=0006649694",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649688",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933MT1W.mp4?latest=0006649692"
+            },
+            "HU": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649652",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933HU1W.mp3?latest=0006649658",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649648",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933HU1W.mp4?latest=0006649654"
+            },
+            "PT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649532",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933PT1W.mp3?latest=0006649538",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649528",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933PT1W.mp4?latest=0006649535"
+            },
+            "PL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649700",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933PL1W.mp3?latest=0006649704",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649698",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933PL1W.mp4?latest=0006649702"
+            },
+            "FR": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649490",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933FR1W.mp3?latest=0006649494",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649488",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933FR1W.mp4?latest=0006649492"
+            },
+            "BG": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649820",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933BG1W.mp3?latest=0006649824",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649818",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933BG1W.mp4?latest=0006649822"
+            },
+            "SV": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649550",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933SV1W.mp3?latest=0006649554",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649548",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933SV1W.mp4?latest=0006649552"
+            },
+            "EN": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649450",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933EN1W.mp3?latest=0006649454",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649448",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933EN1W.mp4?latest=0006649452"
+            },
+            "ET": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649640",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933ET1W.mp3?latest=0006649644",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649638",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933ET1W.mp4?latest=0006649642"
+            },
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006651085",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/HD_I162933INT1W.mp4?latest=0006651091",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933INT1W.mp3?latest=0006651089",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006651083",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933INT1W.mp4?latest=0006651087"
+            },
+            "ES": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649460",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933ES1W.mp3?latest=0006649464",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649458",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933ES1W.mp4?latest=0006649462"
+            },
+            "NL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649520",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933NL1W.mp3?latest=0006649524",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649518",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933NL1W.mp4?latest=0006649522"
+            },
+            "DE": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649430",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933DE1W.mp3?latest=0006649434",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649428",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933DE1W.mp4?latest=0006649432"
+            },
+            "EL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649440",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933EL1W.mp3?latest=0006649444",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649438",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933EL1W.mp4?latest=0006649442"
+            },
+            "FI": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_M_I162933INT1W_07.jpg?latest=0006649472",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/MP3_I162933FI1W.mp3?latest=0006649478",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/THUMB_I162933INT1W_07.jpg?latest=0006649468",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/13\/162933\/LR_I162933FI1W.mp4?latest=0006649474"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163252",
+        "duration": "187.6",
+        "titles_json": {
+          "FR": " Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe: - extracts from the MEPs debate",
+          "EN": " Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe: - extracts from the MEPs debate"
+        },
+        "shootstartdate": "20181113 00:00",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/163252\/THUMB_M_I163252INT1W_3.jpg?latest=0006652035",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/163252\/HD_I163252INT1W.mp4?latest=0006652041",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/163252\/MP3_I163252INT1W.mp3?latest=0006652039",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/163252\/THUMB_I163252INT1W_3.jpg?latest=0006652033",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/163252\/LR_I163252INT1W.mp4?latest=0006652037"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-162938",
+        "duration": "0",
+        "titles_json": {
+          "FR": " LIVE EP Plenary session Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe ",
+          "EN": " LIVE EP Plenary session Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe "
+        },
+        "summary_json": {
+          "FR": " Catch the eye ",
+          "EN": " Catch the eye "
+        },
+        "shootstartdate": "20181113 00:00",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "TEXT": "English",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "FR": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Français",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "DE": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Deutsch",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "IT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Italiano",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "ES": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Espanol",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "EL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Ελληνικά",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "PL": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Polski",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          },
+          {
+            "RO": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Română",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "PL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006649560",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006649558",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938PL1W.mp4?latest=0006649562"
+            },
+            "FR": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006649110",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006649108",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938FR1W.mp4?latest=0006649114"
+            },
+            "EN": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006648318",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006648316",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938EN1W.mp4?latest=0006648320"
+            },
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006649150",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/HD_I162938INT1W.mp4?latest=0006649156",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006649148",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938INT1W.mp4?latest=0006649152"
+            },
+            "ES": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006648330",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006648326",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938ES1W.mp4?latest=0006648334"
+            },
+            "DE": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006648286",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006648284",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938DE1W.mp4?latest=0006648288"
+            },
+            "RO": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006649580",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006649578",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938RO1W.mp4?latest=0006649582"
+            },
+            "IT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006649160",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006649158",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938IT1W.mp4?latest=0006649162"
+            },
+            "EL": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_M_I162938INT1W_05.jpg?latest=0006648308",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/THUMB_I162938INT1W_05.jpg?latest=0006648306",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/18\/162938\/LR_I162938EL1W.mp4?latest=0006648310"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163250",
+        "duration": "262.8",
+        "titles_json": {
+          "FR": " Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe: - extracts from the opening statements",
+          "EN": " Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe: - extracts from the opening statements"
+        },
+        "shootstartdate": "20181113 17:45",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163250\/THUMB_M_I163250INT1W_3.jpg?latest=0006652003",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163250\/HD_I163250INT1W.mp4?latest=0006652009",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163250\/MP3_I163250INT1W.mp3?latest=0006652007",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163250\/THUMB_I163250INT1W_3.jpg?latest=0006652001",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/10\/163250\/LR_I163250INT1W.mp4?latest=0006652005"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163411",
+        "duration": "210.8",
+        "titles_json": {
+          "FR": " Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe:  - extracts from the closing statement",
+          "EN": " Debate with Angela MERKEL, Chancellor of Germany on the Future of Europe:  - extracts from the closing statement"
+        },
+        "shootstartdate": "20181113 19:00",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/11\/163411\/THUMB_M_I163411INT1W_3.jpg?latest=0006653648",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/11\/163411\/HD_I163411INT1W.mp4?latest=0006653654",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/11\/163411\/MP3_I163411INT1W.mp3?latest=0006653652",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/11\/163411\/THUMB_I163411INT1W_3.jpg?latest=0006653646",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/11\/163411\/LR_I163411INT1W.mp4?latest=0006653650"
+            }
+          }
+        },
+        "type": "VIDEO"
+      },
+      {
+        "ref": "I-163245",
+        "duration": "129",
+        "titles_json": {
+          "FR": " Antonio TAJANI, EP President meets with Angela MERKEL, Chancellor of Germany on the Future of Europe: - arrival and roundtable",
+          "EN": " Antonio TAJANI, EP President meets with Angela MERKEL, Chancellor of Germany on the Future of Europe: - arrival and roundtable"
+        },
+        "shootstartdate": "20181113 22:15",
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "TEXT": "Original",
+              "ASPECT": {
+                "16:9": "TRUE"
+              }
+            }
+          }
+        ],
+        "media_json": {
+          "16:9": {
+            "INT": {
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163245\/THUMB_M_I163245INT1W_4.jpg?latest=0006650278",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163245\/HD_I163245INT1W.mp4?latest=0006650284",
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163245\/MP3_I163245INT1W.mp3?latest=0006650282",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163245\/THUMB_I163245INT1W_4.jpg?latest=0006650276",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/05\/163245\/LR_I163245INT1W.mp4?latest=0006650280"
+            }
+          }
+        },
+        "type": "VIDEO"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_mock/src/AvPortalClientMiddleware.php
+++ b/tests/modules/media_avportal_mock/src/AvPortalClientMiddleware.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_avportal_mock;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * A Guzzle middleware for testing the AV Portal service.
+ *
+ * This is used to intercept requests made to AV Portal and return responses
+ * stored in JSON files.
+ *
+ * This is not intended for production use.
+ */
+class AvPortalClientMiddleware {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected $eventDispatcher;
+
+  /**
+   * AvPortalClientMiddleware constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory, EventDispatcherInterface $eventDispatcher) {
+    $this->configFactory = $configFactory;
+    $this->eventDispatcher = $eventDispatcher;
+  }
+
+  /**
+   * HTTP middleware that returns pre-saved data for AV Portal requests.
+   */
+  public function __invoke() {
+    // For AV Portal requests, we need to skip the execution to the remote
+    // service and instead return pre-saved values.
+    return function ($handler) {
+      $config = $this->configFactory->get('media_avportal.settings');
+      return function (RequestInterface $request, array $options) use ($handler, $config) {
+        $uri = $request->getUri();
+
+        // AV Portal API.
+        if ($uri->getScheme() . '://' . $uri->getHost() . $uri->getPath() === $config->get('client_api_uri')) {
+          return $this->createServicePromise($request);
+        }
+
+        // AV Portal thumbnails.
+        if ($uri->getHost() === 'defiris.ec.streamcloud.be') {
+          $thumbnail = file_get_contents(drupal_get_path('module', 'media') . '/images/icons/no-thumbnail.png');
+          $response = new Response(200, [], $thumbnail);
+          return new FulfilledPromise($response);
+        }
+
+        // Otherwise, no intervention. We defer to the handler stack.
+        return $handler($request, $options)
+          ->then(function (ResponseInterface $response) use ($request, $config) {
+            return $response;
+          });
+      };
+    };
+  }
+
+  /**
+   * Creates responses from pre-saved JSON data.
+   *
+   * @param \Psr\Http\Message\RequestInterface $request
+   *   The Guzzle request.
+   *
+   * @return \GuzzleHttp\Promise\PromiseInterface
+   *   The Guzzle promise.
+   */
+  protected function createServicePromise(RequestInterface $request) {
+    // Dispatch event to gather the JSON data for responses.
+    $event = new AvPortalMockEvent($request);
+    $event = $this->eventDispatcher->dispatch(AvPortalMockEvent::AV_PORTAL_MOCK_EVENT, $event);
+
+    $uri = $request->getUri();
+    $query = $uri->getQuery();
+    $params = [];
+    parse_str($query, $params);
+
+    if (isset($params['ref'])) {
+      // It means we are requesting a particular resource.
+      $resources = $event->getResources();
+      if (isset($resources[$params['ref']])) {
+        $resource = $resources[$params['ref']];
+        $response = new Response(200, [], $resource);
+        return new FulfilledPromise($response);
+      }
+      // If our ref is not mocked, we consider it as a not found resource.
+      $resource = $resources['not-found'];
+      $response = new Response(200, [], $resource);
+      return new FulfilledPromise($response);
+    }
+
+    // If we are searching, we need to look at some search responses.
+    if (isset($params['kwand'])) {
+      $searches = $event->getSearches();
+      $json = isset($searches[$params['kwand']]) ? $searches[$params['kwand']] : $searches['empty'];
+    }
+    else {
+      // Otherwise, we default to the regular response.
+      $json = $event->getDefault();
+    }
+
+    // For both default and search query, we need to account for pagination.
+    $decoded = json_decode($json);
+    // Index starts with 1 in AV Portal so we need to subtract 1.
+    $index = (int) $params['index'] - 1;
+    $length = (int) $params['pagesize'];
+    $docs = array_slice($decoded->response->docs, $index, $length);
+    $decoded->response->docs = $docs;
+    $decoded->responseHeader->params->index = $params['index'];
+    $decoded->responseHeader->params->pagesize = $params['pagesize'];
+    $json = json_encode($decoded);
+
+    $response = new Response(200, [], $json);
+    return new FulfilledPromise($response);
+  }
+
+}

--- a/tests/modules/media_avportal_mock/src/AvPortalMockEvent.php
+++ b/tests/modules/media_avportal_mock/src/AvPortalMockEvent.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_avportal_mock;
+
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event used to collect the mocking JSON data.
+ */
+class AvPortalMockEvent extends Event {
+
+  /**
+   * Event name.
+   */
+  const AV_PORTAL_MOCK_EVENT = 'media_avportal_mock.event';
+
+  /**
+   * The Guzzle request.
+   *
+   * @var \Psr\Http\Message\RequestInterface
+   */
+  protected $request;
+
+  /**
+   * The resources JSON data.
+   *
+   * @var array
+   */
+  protected $resources;
+
+  /**
+   * The searches JSON data.
+   *
+   * @var array
+   */
+  protected $searches;
+
+  /**
+   * The default JSON response data.
+   *
+   * @var string
+   */
+  protected $default;
+
+  /**
+   * AvPortalMockEvent constructor.
+   *
+   * @param \Psr\Http\Message\RequestInterface $request
+   *   The Guzzle request.
+   * @param array $resources
+   *   The resources JSON data.
+   * @param array $searches
+   *   The searches JSON data.
+   * @param string $default
+   *   The default JSON response data.
+   */
+  public function __construct(RequestInterface $request, array $resources = [], array $searches = [], string $default = NULL) {
+    $this->resources = $resources;
+    $this->searches = $searches;
+    $this->default = $default;
+    $this->request = $request;
+  }
+
+  /**
+   * Getter.
+   *
+   * @return array
+   *   The resources.
+   */
+  public function getResources(): array {
+    return $this->resources;
+  }
+
+  /**
+   * Setter.
+   *
+   * @param array $resources
+   *   The resources.
+   */
+  public function setResources(array $resources): void {
+    $this->resources = $resources;
+  }
+
+  /**
+   * Getter.
+   *
+   * @return array
+   *   The searches.
+   */
+  public function getSearches(): array {
+    return $this->searches;
+  }
+
+  /**
+   * Setter.
+   *
+   * @param array $searches
+   *   The searches.
+   */
+  public function setSearches(array $searches): void {
+    $this->searches = $searches;
+  }
+
+  /**
+   * Getter.
+   *
+   * @return string
+   *   The default JSON.
+   */
+  public function getDefault(): ?string {
+    return $this->default;
+  }
+
+  /**
+   * Setter.
+   *
+   * @param string $default
+   *   The default JSON.
+   */
+  public function setDefault(string $default): void {
+    $this->default = $default;
+  }
+
+}

--- a/tests/modules/media_avportal_mock/src/EventSubscriber/AvPortalMockEventSubscriber.php
+++ b/tests/modules/media_avportal_mock/src/EventSubscriber/AvPortalMockEventSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_avportal_mock\EventSubscriber;
+
+use Drupal\media_avportal_mock\AvPortalMockEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Default event subscriber for the AV Portal mock.
+ */
+class AvPortalMockEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // We want a high priority for early execution so that it acts as defaults.
+    return [AvPortalMockEvent::AV_PORTAL_MOCK_EVENT => ['setMockResources', 100]];
+  }
+
+  /**
+   * Sets the default resource JSON on the event.
+   *
+   * @param \Drupal\media_avportal_mock\AvPortalMockEvent $event
+   *   The event.
+   */
+  public function setMockResources(AvPortalMockEvent $event) {
+    $resources = $event->getResources();
+    foreach (glob(drupal_get_path('module', 'media_avportal_mock') . '/responses/resources/*.json') as $file) {
+      $ref = str_replace('.json', '', basename($file));
+      $resources[$ref] = file_get_contents($file);
+    }
+
+    $event->setResources($resources);
+
+    $searches = $event->getSearches();
+    foreach (glob(drupal_get_path('module', 'media_avportal_mock') . '/responses/searches/*.json') as $file) {
+      $ref = str_replace('.json', '', basename($file));
+      if (!isset($searches[$ref])) {
+        // We only add the default search if another subscriber did not yet
+        // already provide a JSON for this search term.
+        $searches[$ref] = file_get_contents($file);
+      }
+    }
+    $event->setSearches($searches);
+    if (!$event->getDefault()) {
+      $event->setDefault(file_get_contents(drupal_get_path('module', 'media_avportal_mock') . '/responses/default.json'));
+    }
+  }
+
+}

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -21,6 +21,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     'node',
     'field_ui',
     'media_avportal',
+    'media_avportal_mock',
   ];
 
   /**
@@ -87,6 +88,8 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $this->drupalGet('media/add/media_av_portal');
     $page->fillField('Media AV Portal Video', 'http://ec.europa.eu/avservices/play.cfm?autoplay=true&lg=EN&ref=I-12345678987654321');
     $page->pressButton('Save');
+
+    $assert_session->pageTextContains('The given URL does not match an AV Portal URL.');
 
     // Create a media content with an invalid resource URL.
     $this->drupalGet('media/add/media_av_portal');


### PR DESCRIPTION
## OPENEUROPA-1329 

### Description

Creating a mock for the AV Portal service so that we can test without depending on the remote AV Portal service. 

This was also needed for OPENEUROPA-1329 where we implement the Views query plugin that uses the AV Portal service.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

