### PR TITLE
OPENEUROPA-1642: Move url logic from widget to media sources

### DIFF
--- a/src/Plugin/Field/FieldWidget/AvPortalWidget.php
+++ b/src/Plugin/Field/FieldWidget/AvPortalWidget.php
@@ -88,7 +88,6 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
 
     // Element description.
     $formats = $this->source->getSupportedUrlFormats();
-    $reference_url = reset($formats);
     $message = $this->t('You can link to media from AV Portal by entering a URL in the formats: @formats', ['@formats' => implode(',', $formats)]);
 
     $element['value']['#description'] = $message;

--- a/src/Plugin/Field/FieldWidget/AvPortalWidget.php
+++ b/src/Plugin/Field/FieldWidget/AvPortalWidget.php
@@ -39,7 +39,7 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
   protected $entityTypeManager;
 
   /**
-   * The source field media source.
+   * The media source for the field.
    *
    * @var |Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface
    */
@@ -89,8 +89,8 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
 
     // Element description.
-    $formats = $this->source->getSupportedUrlsFormat();
-    $referenceUrl = reset($formats);
+    $formats = $this->source->getSupportedUrlFormats();
+    $reference_url = reset($formats);
     $message = $this->t('You can link to media from AV Portal by entering a URL in the formats: @formats', ['@formats' => implode(',', $formats)]);
 
     $element['value']['#description'] = $message;
@@ -104,7 +104,7 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
     }
 
     if ($this->source instanceof MediaAvPortalSourceBase) {
-      $element['#valid_urls'] = $this->source->getSupportedUrlsPatterns();
+      $element['#valid_urls'] = $this->source->getSupportedUrlPatterns();
       $element['#element_validate'] = [
         [static::class, 'validate'],
       ];
@@ -115,11 +115,11 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
     if (!empty($element['value']['#default_value'])) {
       // Video.
       if (preg_match('/I\-(\d+)/', $element['value']['#default_value'])) {
-        $element['value']['#default_value'] = str_replace('[REF]', $element['value']['#default_value'], $referenceUrl);
+        $element['value']['#default_value'] = str_replace('[REF]', $element['value']['#default_value'], $reference_url);
       }
       // Photo.
       elseif (preg_match('/P\-(\d+)\/(\d+)\-(\d+)/', $element['value']['#default_value'], $matches)) {
-        $element['value']['#default_value'] = str_replace('[REF]', $matches[1] . '#' . ($matches[3] - 1), $referenceUrl);
+        $element['value']['#default_value'] = str_replace('[REF]', $matches[1] . '#' . ($matches[3] - 1), $reference_url);
       }
     }
 

--- a/src/Plugin/Field/FieldWidget/AvPortalWidget.php
+++ b/src/Plugin/Field/FieldWidget/AvPortalWidget.php
@@ -12,7 +12,6 @@ use Drupal\Core\Field\Plugin\Field\FieldWidget\StringTextfieldWidget;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\media\Entity\MediaType;
-use Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceBase;
 use Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -100,12 +99,10 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
       ];
     }
 
-    if ($this->source instanceof MediaAvPortalSourceBase) {
-      $element['#valid_urls'] = $this->source->getSupportedUrlPatterns();
-      $element['#element_validate'] = [
-        [static::class, 'validate'],
-      ];
-    }
+    $element['#valid_urls'] = $this->source->getSupportedUrlPatterns();
+    $element['#element_validate'] = [
+      [static::class, 'validate'],
+    ];
 
     if (!empty($element['value']['#default_value'])) {
       $element['value']['#default_value'] = $this->source->transformReferenceToUrl($element['value']['#default_value']);

--- a/src/Plugin/Field/FieldWidget/AvPortalWidget.php
+++ b/src/Plugin/Field/FieldWidget/AvPortalWidget.php
@@ -153,7 +153,7 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
         return $value;
       }
 
-      $reference = $this->source->transformUrlToReference($url['query']['ref']);
+      $reference = $this->source->transformUrlToReference($url);
 
       if (!empty($reference)) {
         $value['value'] = $reference;

--- a/src/Plugin/Field/FieldWidget/AvPortalWidget.php
+++ b/src/Plugin/Field/FieldWidget/AvPortalWidget.php
@@ -39,7 +39,7 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
   /**
    * The media source for the field.
    *
-   * @var |Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface
+   * @var \Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface
    */
   protected $source;
 

--- a/src/Plugin/Field/FieldWidget/AvPortalWidget.php
+++ b/src/Plugin/Field/FieldWidget/AvPortalWidget.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\media_avportal\Plugin\Field\FieldWidget;
 
-use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -143,13 +142,7 @@ class AvPortalWidget extends StringTextfieldWidget implements ContainerFactoryPl
     // in the field value.
     foreach ($values as $value) {
 
-      $url = UrlHelper::parse($value['value']);
-
-      if (!isset($url['query']['ref'])) {
-        return $value;
-      }
-
-      $reference = $this->source->transformUrlToReference($url);
+      $reference = $this->source->transformUrlToReference($value['value']);
 
       if (!empty($reference)) {
         $value['value'] = $reference;

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -69,7 +69,6 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
    * {@inheritdoc}
    */
   public function transformUrlToReference(string $url): string {
-
     $structured_url = UrlHelper::parse($url);
 
     if (!isset($structured_url['query']['ref'])) {
@@ -92,7 +91,6 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
    * {@inheritdoc}
    */
   public function transformReferenceToUrl(string $reference): string {
-
     $formats = $this->getSupportedUrlFormats();
     $reference_url = reset($formats);
     $matches = [];

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -22,6 +22,24 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
+  public function getSupportedUrlsFormat() {
+    return [
+      'https://ec.europa.eu/avservices/photo/photoDetails.cfm?sitelang=en&ref=[REF]',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSupportedUrlsPatterns() {
+    return [
+      '@ec\.europa\.eu/avservices/photo/photoDetails.cfm?(.+)@i',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getMetadataAttributes(): array {
     return parent::getMetadataAttributes() + [
       'photo_uri' => $this->t('Photo URI'),

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -22,7 +22,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsFormat() : array {
+  public function getSupportedUrlFormats(): array {
     return [
       'https://ec.europa.eu/avservices/photo/photoDetails.cfm?sitelang=en&ref=[REF]',
     ];
@@ -31,7 +31,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsPatterns() : array {
+  public function getSupportedUrlPatterns(): array {
     return [
       '@ec\.europa\.eu/avservices/photo/photoDetails.cfm?(.+)@i',
     ];

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -64,4 +64,32 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
     return parent::getMetadata($media, $name);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function transformUrlToReference(string $url): ?string {
+    preg_match('/(\d+)/', $url, $matches);
+    // The reference should be in the format P-xxxx-00-yy where xxxx and
+    // yy are numbers.
+    // Sometimes no dash is present, so we have to normalise the reference
+    // back.
+    if (isset($matches[0])) {
+      return 'P-' . $matches[0] . '/00-' . sprintf('%02d', $url['fragment'] + 1);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transformReferenceToUrl(string $reference): ?string {
+
+    $formats = $this->getSupportedUrlFormats();
+    $reference_url = reset($formats);
+    $matches = [];
+
+    if (preg_match('/P\-(\d+)\/(\d+)\-(\d+)/', $reference, $matches)) {
+      return str_replace('[REF]', $matches[1] . '#' . ($matches[3] - 1), $reference_url);
+    }
+  }
+
 }

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -67,8 +67,8 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function transformUrlToReference(string $url): ?string {
-    preg_match('/(\d+)/', $url, $matches);
+  public function transformUrlToReference(array $url): ?string {
+    preg_match('/(\d+)/', $url['query']['ref'], $matches);
     // The reference should be in the format P-xxxx-00-yy where xxxx and
     // yy are numbers.
     // Sometimes no dash is present, so we have to normalise the reference

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -67,7 +67,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function transformUrlToReference(array $url): ?string {
+  public function transformUrlToReference(array $url): string {
     preg_match('/(\d+)/', $url['query']['ref'], $matches);
     // The reference should be in the format P-xxxx-00-yy where xxxx and
     // yy are numbers.
@@ -76,12 +76,14 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
     if (isset($matches[0])) {
       return 'P-' . $matches[0] . '/00-' . sprintf('%02d', $url['fragment'] + 1);
     }
+
+    return '';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function transformReferenceToUrl(string $reference): ?string {
+  public function transformReferenceToUrl(string $reference): string {
 
     $formats = $this->getSupportedUrlFormats();
     $reference_url = reset($formats);
@@ -90,6 +92,8 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
     if (preg_match('/P\-(\d+)\/(\d+)\-(\d+)/', $reference, $matches)) {
       return str_replace('[REF]', $matches[1] . '#' . ($matches[3] - 1), $reference_url);
     }
+
+    return '';
   }
 
 }

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\media_avportal\Plugin\media\Source;
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\media\MediaInterface;
 
 /**
@@ -67,14 +68,21 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function transformUrlToReference(array $url): string {
-    preg_match('/(\d+)/', $url['query']['ref'], $matches);
+  public function transformUrlToReference(string $url): string {
+
+    $structured_url = UrlHelper::parse($url);
+
+    if (!isset($structured_url['query']['ref'])) {
+      return $url;
+    }
+
+    preg_match('/(\d+)/', $structured_url['query']['ref'], $matches);
     // The reference should be in the format P-xxxx-00-yy where xxxx and
     // yy are numbers.
     // Sometimes no dash is present, so we have to normalise the reference
     // back.
     if (isset($matches[0])) {
-      return 'P-' . $matches[0] . '/00-' . sprintf('%02d', $url['fragment'] + 1);
+      return 'P-' . $matches[0] . '/00-' . sprintf('%02d', $structured_url['fragment'] + 1);
     }
 
     return '';

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -22,7 +22,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsFormat() {
+  public function getSupportedUrlsFormat() : array {
     return [
       'https://ec.europa.eu/avservices/photo/photoDetails.cfm?sitelang=en&ref=[REF]',
     ];
@@ -31,7 +31,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsPatterns() {
+  public function getSupportedUrlsPatterns() : array {
     return [
       '@ec\.europa\.eu/avservices/photo/photoDetails.cfm?(.+)@i',
     ];

--- a/src/Plugin/media/Source/MediaAvPortalSourceBase.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceBase.php
@@ -236,7 +236,6 @@ abstract class MediaAvPortalSourceBase extends MediaSourceBase implements MediaA
    *   resource has no thumbnail at all.
    */
   protected function importRemoteThumbnail(AvPortalResource $resource, string $local_thumbnail_uri):? string {
-
     $configuration = $this->getConfiguration();
     $directory = $configuration['thumbnails_directory'];
 

--- a/src/Plugin/media/Source/MediaAvPortalSourceBase.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceBase.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Media Source base class for AV Portal Sources.
  */
-class MediaAvPortalSourceBase extends MediaSourceBase implements MediaAvPortalSourceInterface {
+abstract class MediaAvPortalSourceBase extends MediaSourceBase implements MediaAvPortalSourceInterface {
 
   /**
    * The logger channel for media.

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -22,15 +22,15 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
   public function getSupportedUrlPatterns(): array;
 
   /**
-   * Transforms string url with resource reference to a simple reference string.
+   * Transforms url with resource reference to a simple reference string.
    *
-   * @param string $url
+   * @param array $url
    *   The url to transform.
    *
    * @return string
    *   The transformed url.
    */
-  public function transformUrlToReference(string $url): ?string;
+  public function transformUrlToReference(array $url): ?string;
 
   /**
    * Transforms a resource reference string to full url with reference.

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -14,11 +14,11 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
   /**
    * Gets list of supported url formats.
    */
-  public function getSupportedUrlsFormat(): array;
+  public function getSupportedUrlFormats(): array;
 
   /**
    * Gets list of supported url patterns.
    */
-  public function getSupportedUrlsPatterns(): array;
+  public function getSupportedUrlPatterns(): array;
 
 }

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -9,4 +9,16 @@ use Drupal\media\MediaSourceFieldConstraintsInterface;
 /**
  * Common interface for source plugins that use the AV Portal.
  */
-interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterface {}
+interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterface {
+
+  /**
+   * Gets list of supported url formats.
+   */
+  public function getSupportedUrlsFormat() : array;
+
+  /**
+   * Gets list of supported url patterns.
+   */
+  public function getSupportedUrlsPatterns() : array;
+
+}

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -14,11 +14,11 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
   /**
    * Gets list of supported url formats.
    */
-  public function getSupportedUrlsFormat() : array;
+  public function getSupportedUrlsFormat(): array;
 
   /**
    * Gets list of supported url patterns.
    */
-  public function getSupportedUrlsPatterns() : array;
+  public function getSupportedUrlsPatterns(): array;
 
 }

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -21,4 +21,26 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
    */
   public function getSupportedUrlPatterns(): array;
 
+  /**
+   * Transforms string url with resource reference to a simple reference string.
+   *
+   * @param string $url
+   *   The url to transform.
+   *
+   * @return string
+   *   The transformed url.
+   */
+  public function transformUrlToReference(string $url): ?string;
+
+  /**
+   * Transforms a resource reference string to full url with reference.
+   *
+   * @param string $reference
+   *   The reference to transform.
+   *
+   * @return string
+   *   The transformed Url.
+   */
+  public function transformReferenceToUrl(string $reference): ?string;
+
 }

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -24,13 +24,13 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
   /**
    * Transforms url with resource reference to a simple reference string.
    *
-   * @param array $url
+   * @param string $url
    *   The url to transform.
    *
    * @return string
    *   The transformed url.
    */
-  public function transformUrlToReference(array $url): string;
+  public function transformUrlToReference(string $url): string;
 
   /**
    * Transforms a resource reference string to full url with reference.

--- a/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
+++ b/src/Plugin/media/Source/MediaAvPortalSourceInterface.php
@@ -30,7 +30,7 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
    * @return string
    *   The transformed url.
    */
-  public function transformUrlToReference(array $url): ?string;
+  public function transformUrlToReference(array $url): string;
 
   /**
    * Transforms a resource reference string to full url with reference.
@@ -41,6 +41,6 @@ interface MediaAvPortalSourceInterface extends MediaSourceFieldConstraintsInterf
    * @return string
    *   The transformed Url.
    */
-  public function transformReferenceToUrl(string $reference): ?string;
+  public function transformReferenceToUrl(string $reference): string;
 
 }

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -39,8 +39,15 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function transformUrlToReference(array $url): string {
-    preg_match('/(\d+)/', $url['query']['ref'], $matches);
+  public function transformUrlToReference(string $url): string {
+
+    $structured_url = UrlHelper::parse($url);
+
+    if (!isset($structured_url['query']['ref'])) {
+      return $url;
+    }
+
+    preg_match('/(\d+)/', $structured_url['query']['ref'], $matches);
 
     // The reference should be in the format I-xxxx where x are numbers.
     // Sometimes no dash is present, so we have to normalise the reference

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -20,7 +20,7 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsFormat() {
+  public function getSupportedUrlsFormat(): array {
     return [
       'https://ec.europa.eu/avservices/video/player.cfm?sitelang=en&ref=[REF]',
     ];
@@ -29,7 +29,7 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsPatterns() {
+  public function getSupportedUrlsPatterns(): array {
     return [
       '@ec\.europa\.eu/avservices/video/player\.cfm\?(.+)@i',
       '@ec\.europa\.eu/avservices/play\.cfm\?(.+)@i',

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -20,7 +20,7 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsFormat(): array {
+  public function getSupportedUrlFormats(): array {
     return [
       'https://ec.europa.eu/avservices/video/player.cfm?sitelang=en&ref=[REF]',
     ];
@@ -29,7 +29,7 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function getSupportedUrlsPatterns(): array {
+  public function getSupportedUrlPatterns(): array {
     return [
       '@ec\.europa\.eu/avservices/video/player\.cfm\?(.+)@i',
       '@ec\.europa\.eu/avservices/play\.cfm\?(.+)@i',

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -39,8 +39,8 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function transformUrlToReference(string $url): ?string {
-    preg_match('/(\d+)/', $url, $matches);
+  public function transformUrlToReference(array $url): ?string {
+    preg_match('/(\d+)/', $url['query']['ref'], $matches);
 
     // The reference should be in the format I-xxxx where x are numbers.
     // Sometimes no dash is present, so we have to normalise the reference

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -39,7 +39,7 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
   /**
    * {@inheritdoc}
    */
-  public function transformUrlToReference(array $url): ?string {
+  public function transformUrlToReference(array $url): string {
     preg_match('/(\d+)/', $url['query']['ref'], $matches);
 
     // The reference should be in the format I-xxxx where x are numbers.
@@ -48,12 +48,14 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
     if (isset($matches[0])) {
       return 'I-' . $matches[0];
     }
+
+    return '';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function transformReferenceToUrl(string $reference): ?string {
+  public function transformReferenceToUrl(string $reference): string {
 
     $formats = $this->getSupportedUrlFormats();
     $reference_url = reset($formats);
@@ -61,6 +63,8 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
     if (preg_match('/I\-(\d+)/', $reference)) {
       return str_replace('[REF]', $reference, $reference_url);
     }
+
+    return '';
   }
 
 }

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -15,4 +15,25 @@ namespace Drupal\media_avportal\Plugin\media\Source;
  *   default_thumbnail_filename = "no-thumbnail.png",
  * )
  */
-class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {}
+class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSupportedUrlsFormat() {
+    return [
+      'https://ec.europa.eu/avservices/video/player.cfm?sitelang=en&ref=[REF]',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSupportedUrlsPatterns() {
+    return [
+      '@ec\.europa\.eu/avservices/video/player\.cfm\?(.+)@i',
+      '@ec\.europa\.eu/avservices/play\.cfm\?(.+)@i',
+    ];
+  }
+
+}

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -36,4 +36,31 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function transformUrlToReference(string $url): ?string {
+    preg_match('/(\d+)/', $url, $matches);
+
+    // The reference should be in the format I-xxxx where x are numbers.
+    // Sometimes no dash is present, so we have to normalise the reference
+    // back.
+    if (isset($matches[0])) {
+      return 'I-' . $matches[0];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transformReferenceToUrl(string $reference): ?string {
+
+    $formats = $this->getSupportedUrlFormats();
+    $reference_url = reset($formats);
+
+    if (preg_match('/I\-(\d+)/', $reference)) {
+      return str_replace('[REF]', $reference, $reference_url);
+    }
+  }
+
 }

--- a/src/Plugin/media/Source/MediaAvPortalVideoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalVideoSource.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\media_avportal\Plugin\media\Source;
 
+use Drupal\Component\Utility\UrlHelper;
+
 /**
  * Provides a media source plugin for Media AV Portal resources.
  *
@@ -40,7 +42,6 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
    * {@inheritdoc}
    */
   public function transformUrlToReference(string $url): string {
-
     $structured_url = UrlHelper::parse($url);
 
     if (!isset($structured_url['query']['ref'])) {
@@ -63,7 +64,6 @@ class MediaAvPortalVideoSource extends MediaAvPortalSourceBase {
    * {@inheritdoc}
    */
   public function transformReferenceToUrl(string $reference): string {
-
     $formats = $this->getSupportedUrlFormats();
     $reference_url = reset($formats);
 


### PR DESCRIPTION
## OPENEUROPA-1642

### Description

Internal field widget URL logic moved to media sources so it can be reused in other components.

### Change log
- Changed: Internal field widget URL logic moved to media sources so it can be reused in other components.

