### PR TITLE
OPENEUROPA-1844: Fixing AV Portal stream wrapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,12 @@
     "require-dev": {
         "composer/installers": "~1.5",
         "drupal-composer/drupal-scaffold": "~2.5.2",
+        "cweagans/composer-patches": "^1.6",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
         "drupal/ctools": "^3.0",
         "drupal/drupal-extension": "~4.0",
+        "drupal/remote_stream_wrapper": "^1.2",
         "drush/drush": "~9.0",
         "nikic/php-parser": "^3.1.5",
         "openeuropa/code-review": "~1.0@beta",
@@ -45,6 +47,11 @@
         }
     },
     "extra": {
+        "patches": {
+            "drupal/remote_stream_wrapper": {
+                "https://www.drupal.org/project/remote_stream_wrapper/issues/3050183": "https://www.drupal.org/files/issues/2019-04-23/3050183-2.patch"
+            }
+        },
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drush/drush": "~9.0",
         "nikic/php-parser": "^3.1.5",
         "openeuropa/code-review": "~1.0@beta",
-        "openeuropa/drupal-core-require-dev": "^8.6",
+        "openeuropa/drupal-core-require-dev": "^8.6.4",
         "openeuropa/task-runner": "~1.0@beta",
         "phpunit/phpunit": "~6.0"
     },

--- a/media_avportal.info.yml
+++ b/media_avportal.info.yml
@@ -5,3 +5,4 @@ package: Media
 core: 8.x
 dependencies:
   - drupal:media
+  - remote_stream_wrapper:remote_stream_wrapper

--- a/tests/src/Kernel/AvPortalStreamWrapperTest.php
+++ b/tests/src/Kernel/AvPortalStreamWrapperTest.php
@@ -17,6 +17,7 @@ class AvPortalStreamWrapperTest extends KernelTestBase {
    */
   protected static $modules = [
     'system',
+    'remote_stream_wrapper',
     'media_avportal',
     'media_avportal_mock',
   ];


### PR DESCRIPTION
## OPENEUROPA-1844

### Description

The AV Portal stream wrapper used for generating image styles based in AV Portal photos did not work correctly for all photos. Some photos were fine while others were not. The issue was traced to the stream wrapper.

The solution (and improvement) is to use a contrib module called [Remote Stream Wrapper](https://www.drupal.org/project/remote_stream_wrapper) which provides a good basis for extending our stream wrapper from. This uses Guzzle streams which does a lot of the heavy lifting. However, the module also makes an assumption we don't want: it prevents image styles from being generated for images that are not somehow managed. Which in our case is not ok because the AV portal photos are not treated as managed files. So I also made an issue and patch to make this assumption extensible for child stream wrappers: https://www.drupal.org/project/remote_stream_wrapper/issues/3050183
