### PR TITLE
OPENEUROPA-1930: Update text filter parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ By default, there are 3 types of requests that are mocked:
 
 * A default request with no options
 * A request for a given resource (the options contain the `ref` key)
-* A request that searches for a given term (the options contain the `kwand` key)
+* A request that searches for a given term (the options contain the `kwgg` key)
 
 Additionally, any request to a resource thumbnail will return a local thumbnail image.
 

--- a/tests/modules/media_avportal_mock/responses/searches/all-empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/all-empty.json
@@ -7,7 +7,7 @@
       "ref": "I-12345678987654321",
       "index": "1",
       "hasmedia": "1",
-      "kwand": "",
+      "kwgg": "",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0100",

--- a/tests/modules/media_avportal_mock/responses/searches/all-europe.json
+++ b/tests/modules/media_avportal_mock/responses/searches/all-europe.json
@@ -7,7 +7,7 @@
       "index": "1",
       "hasmedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
-      "kwand": "europe",
+      "kwgg": "europe",
       "proxy": "true",
       "serverName": "wlpc0099",
       "type": "",

--- a/tests/modules/media_avportal_mock/responses/searches/photo-empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/photo-empty.json
@@ -7,7 +7,7 @@
       "ref": "I-12345678987654321",
       "index": "1",
       "hasmedia": "1",
-      "kwand": "",
+      "kwgg": "",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0100",

--- a/tests/modules/media_avportal_mock/responses/searches/photo-europe.json
+++ b/tests/modules/media_avportal_mock/responses/searches/photo-europe.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "index": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
-      "kwand": "europe",
+      "kwgg": "europe",
       "proxy": "true",
       "serverName": "wlpc0099",
       "type": "PHOTO",

--- a/tests/modules/media_avportal_mock/responses/searches/video-empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/video-empty.json
@@ -7,7 +7,7 @@
       "ref": "I-12345678987654321",
       "index": "1",
       "hasmedia": "1",
-      "kwand": "",
+      "kwgg": "",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0100",

--- a/tests/modules/media_avportal_mock/responses/searches/video-europe.json
+++ b/tests/modules/media_avportal_mock/responses/searches/video-europe.json
@@ -7,7 +7,7 @@
       "index": "1",
       "hasmedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
-      "kwand": "europe",
+      "kwgg": "europe",
       "proxy": "true",
       "serverName": "wlpc0099",
       "type": "VIDEO",

--- a/tests/modules/media_avportal_mock/src/AvPortalClientMiddleware.php
+++ b/tests/modules/media_avportal_mock/src/AvPortalClientMiddleware.php
@@ -116,9 +116,9 @@ class AvPortalClientMiddleware {
     }
 
     // If we are searching, we need to look at some search responses.
-    if (isset($params['kwand'])) {
+    if (isset($params['kwgg'])) {
       $searches = $event->getSearches();
-      $json = isset($searches[$resource_type . '-' . $params['kwand']]) ? $searches[$resource_type . '-' . $params['kwand']] : $searches[$resource_type . '-empty'];
+      $json = isset($searches[$resource_type . '-' . $params['kwgg']]) ? $searches[$resource_type . '-' . $params['kwgg']] : $searches[$resource_type . '-empty'];
     }
     else {
       // Otherwise, we default to the regular response.


### PR DESCRIPTION
## OPENEUROPA-1930
### Description

The text filters on the AVPortal resource views don't work anymore.

The name of the parameters to filter by text changed on the end service so its been updated.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

