### PR TITLE
OPENEUROPA-2052: Add supporting of AV Portal URLs with album.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ services:
     environment:
     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
   selenium:
-    image: selenium/standalone-chrome:3
+    image: selenium/standalone-chrome:3.141.59-oxygen
     shm_size: 2g
     environment:
     - DISPLAY=:99

--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -34,6 +34,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
   public function getSupportedUrlPatterns(): array {
     return [
       '@audiovisual\.ec\.europa\.eu/(.*)/photo/(P\-.*\~2F.*)@i' => 'handlePhotoFullUrlPattern',
+      '@audiovisual\.ec\.europa\.eu/(.*)/album/M\-[0-9]*/(P\-.*\~2F.*)@i' => 'handlePhotoFullUrlPattern',
     ];
   }
 

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -163,17 +163,17 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
     $this->assertContains('P038924-352937.jpg', $image_url);
 
+    // We need to support both individual photos and photos inside albums.
     $photo_urls = [
       'https://audiovisual.ec.europa.eu/en/album/M-090909/P-039162~2F00-12',
       'https://audiovisual.ec.europa.eu/en/photo/P-039162~2F00-12',
     ];
 
-    // We could update photo with different URL formats supporting.
     foreach ($photo_urls as $photo_url) {
       // Edit the newly created media.
       $this->drupalGet('media/1/edit');
 
-      // Update the field with url from album.
+      // Update the field.
       $page->fillField('Media AV Portal Photo', $photo_url);
       $page->pressButton('Save');
 

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -86,7 +86,6 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $this->assertContains('ref=I-162747', $iframe_url);
 
     // @todo assert the width and height of the iframe.
-
     // Edit the newly created media.
     $this->drupalGet('media/1/edit');
 
@@ -164,20 +163,28 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
     $this->assertContains('P038924-352937.jpg', $image_url);
 
-    // Edit the newly created media.
-    $this->drupalGet('media/1/edit');
+    $photo_urls = [
+      'https://audiovisual.ec.europa.eu/en/album/M-090909/P-039162~2F00-12',
+      'https://audiovisual.ec.europa.eu/en/photo/P-039162~2F00-12',
+    ];
 
-    // Update the field.
-    $page->fillField('Media AV Portal Photo', 'https://audiovisual.ec.europa.eu/en/photo/P-039162~2F00-12');
-    $page->pressButton('Save');
+    // We could update photo with different URL formats supporting.
+    foreach ($photo_urls as $photo_url) {
+      // Edit the newly created media.
+      $this->drupalGet('media/1/edit');
 
-    // Visit the updated media content.
-    $page->clickLink('Andrus Ansip Vice-President of the EC addresses the Plenary of the European Parliament on the beginning of the Romanian Presidency of the Council of the EU');
+      // Update the field with url from album.
+      $page->fillField('Media AV Portal Photo', $photo_url);
+      $page->pressButton('Save');
 
-    // Check the image URL.
-    $image_url = $assert_session->elementExists('css', 'img.avportal-photo')->getAttribute('src');
-    $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
-    $this->assertContains('P039162-137797.jpg', $image_url);
+      // Visit the updated media content.
+      $page->clickLink('Andrus Ansip Vice-President of the EC addresses the Plenary of the European Parliament on the beginning of the Romanian Presidency of the Council of the EU');
+
+      // Check the image URL.
+      $image_url = $assert_session->elementExists('css', 'img.avportal-photo')->getAttribute('src');
+      $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
+      $this->assertContains('P039162-137797.jpg', $image_url);
+    }
 
     // Create a media content with an invalid reference.
     $this->drupalGet('media/add/media_av_portal_photo');


### PR DESCRIPTION
## OPENEUROPA-2052

### Description

Actual result:

As a CMS user 
When I visit "the media/add/av_portal_photo"
And I fill in Media AV Portal Photo with https://audiovisual.ec.europa.eu/en/album/M-000758/P-026777~2F00-02
And I press Save
Then I receive an error "Invalid URL format specified." (see attachment)

Expected result:

As a CMS user
When I visit "the media/add/av_portal_photo"
I should be able to add https://audiovisual.ec.europa.eu/en/album/M-000758/P-026777~2F00-02 as a media file

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

