### PR TITLE
OPENEUROPA-2151: The URL is changing when user tries to edit AV Portal Photo.

### DIFF
--- a/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
+++ b/src/Plugin/media/Source/MediaAvPortalPhotoSource.php
@@ -98,7 +98,7 @@ class MediaAvPortalPhotoSource extends MediaAvPortalSourceBase {
     $matches = [];
 
     if (preg_match('/(P\-\d+)\/(\d+)\-(\d+)/', $reference, $matches)) {
-      return str_replace('[REF]', $matches[1] . '~2F' . $matches[2] . '-' . ($matches[3] - 1), $reference_url);
+      return str_replace('[REF]', $matches[1] . '~2F' . $matches[2] . '-' . $matches[3], $reference_url);
     }
 
     return '';

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -163,8 +163,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
     $this->assertContains('P038924-352937.jpg', $image_url);
 
-    // Make sure that default value of media URL is normalized
-    // (have format like https://audiovisual.ec.europa.eu/en/photo/[REF]).
+    // Make sure that the media URL is normalized back to the correct format.
     $this->drupalGet('media/1/edit');
     $this->assertSession()->fieldValueEquals('Media AV Portal Photo', 'https://audiovisual.ec.europa.eu/en/photo/P-038924~2F00-15');
 
@@ -191,8 +190,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
       $this->assertContains('P039162-137797.jpg', $image_url);
     }
 
-    // Make sure that default value of media URL is normalized
-    // (have format like https://audiovisual.ec.europa.eu/en/photo/[REF]).
+    // Make sure that the media URL is normalized back to the correct format.
     $this->drupalGet('media/1/edit');
     $this->assertSession()->fieldValueEquals('Media AV Portal Photo', reset($photo_urls));
 

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -163,10 +163,15 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
     $this->assertContains('P038924-352937.jpg', $image_url);
 
+    // Make sure that default value of media URL is normalized
+    // (have format like https://audiovisual.ec.europa.eu/en/photo/[REF]).
+    $this->drupalGet('media/1/edit');
+    $this->assertSession()->fieldValueEquals('Media AV Portal Photo', 'https://audiovisual.ec.europa.eu/en/photo/P-038924~2F00-15');
+
     // We need to support both individual photos and photos inside albums.
     $photo_urls = [
-      'https://audiovisual.ec.europa.eu/en/album/M-090909/P-039162~2F00-12',
       'https://audiovisual.ec.europa.eu/en/photo/P-039162~2F00-12',
+      'https://audiovisual.ec.europa.eu/en/album/M-090909/P-039162~2F00-12',
     ];
 
     foreach ($photo_urls as $photo_url) {
@@ -185,6 +190,11 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
       $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
       $this->assertContains('P039162-137797.jpg', $image_url);
     }
+
+    // Make sure that default value of media URL is normalized
+    // (have format like https://audiovisual.ec.europa.eu/en/photo/[REF]).
+    $this->drupalGet('media/1/edit');
+    $this->assertSession()->fieldValueEquals('Media AV Portal Photo', reset($photo_urls));
 
     // Create a media content with an invalid reference.
     $this->drupalGet('media/add/media_av_portal_photo');


### PR DESCRIPTION
## OPENEUROPA-2151

### Description

Steps to reproduce:

Add a photo on Media -> Av Portal Photo and verify the URL (eg https://audiovisual.ec.europa.eu/en/photo/P-040700~2F00-01)
Edit the photo from step 1
Verify the URL from the field
Actual result:

URLs are different 

Expected result:

URLs should be the same.

NOTE: If the user doesn't modify the URL in the editing step and tries to save the photo he gets an error " The given URL does not match an AV Portal URL"

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

