### PR TITLE
OPENEUROPA-2165: [media_avportal] Missing information for some videos.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "drupal/remote_stream_wrapper": "^1.2"
     },
     "require-dev": {
+        "behat/mink-selenium2-driver": "1.4.x-dev as 1.3.x-dev",
         "composer/installers": "~1.5",
         "drupal-composer/drupal-scaffold": "~2.5.2",
         "cweagans/composer-patches": "^1.6",

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  media_avportal.commands:
+    class: \Drupal\media_avportal\Commands\AvPortalCommands
+    arguments: ['@media_avportal.avportal_pull_media']
+    tags:
+      - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   media_avportal.commands:
-    class: \Drupal\media_avportal\Commands\AvPortalCommands
-    arguments: ['@media_avportal.avportal_pull_media']
+    class: Drupal\media_avportal\Commands\AvPortalCommands
+    arguments: ['@media_avportal.media_updater']
     tags:
       - { name: drush.command }

--- a/media_avportal.services.yml
+++ b/media_avportal.services.yml
@@ -6,6 +6,6 @@ services:
     class: Drupal\media_avportal\StreamWrapper\AvPortalPhotoStreamWrapper
     tags:
       - { name: stream_wrapper, scheme: avportal }
-  media_avportal.avportal_pull_media:
-    class: Drupal\media_avportal\AvPortalPullMedia
+  media_avportal.media_updater:
+    class: Drupal\media_avportal\AvPortalMediaUpdater
     arguments: ['@entity_type.manager', '@logger.factory']

--- a/media_avportal.services.yml
+++ b/media_avportal.services.yml
@@ -6,3 +6,6 @@ services:
     class: Drupal\media_avportal\StreamWrapper\AvPortalPhotoStreamWrapper
     tags:
       - { name: stream_wrapper, scheme: avportal }
+  media_avportal.avportal_pull_media:
+    class: Drupal\media_avportal\AvPortalPullMedia
+    arguments: ['@entity_type.manager', '@logger.factory']

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
     <env name="MINK_DRIVER_CLASS" value="Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver"/>
     <env name="MINK_DRIVER_ARGS" value='["${selenium.host}"]'/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["${selenium.browser}", null, "${selenium.host}/wd/hub"]'/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["${selenium.browser}", null, "${selenium.host}:${selenium.port}/wd/hub"]'/>
   </php>
   <testsuites>
     <testsuite>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -30,7 +30,8 @@ drupal:
         - "${drupal.root}"
 
 selenium:
-  host: "http://selenium:4444"
+  host: "http://selenium"
+  port: "4444"
   browser: "chrome"
 
 commands:

--- a/src/AvPortalMediaUpdater.php
+++ b/src/AvPortalMediaUpdater.php
@@ -9,9 +9,9 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 
 /**
- * Class of the service for fetching/refreshing AVPortal media entities.
+ * Service to update AV Portal media entities.
  */
-class AvPortalPullMedia {
+class AvPortalMediaUpdater {
 
   use DependencySerializationTrait;
 
@@ -30,7 +30,7 @@ class AvPortalPullMedia {
   protected $loggerChannelFactory;
 
   /**
-   * Creates AvPortalPullMedia objects.
+   * Creates a new AvPortalMediaUpdater objects.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
@@ -43,12 +43,12 @@ class AvPortalPullMedia {
   }
 
   /**
-   * Pull for updating existing media from AV Portal service.
+   * Refresh from the source all the mapped fields of AV Portal medias.
    *
    * @param array $media_ids
    *   Array of media ids.
    */
-  public function pullAvPortalMedia(array $media_ids = NULL): void {
+  public function refreshMappedFields(array $media_ids = NULL): void {
     /** @var \Drupal\media\Entity\Media[] $medias */
     $medias = $this->entityTypeManager->getStorage('media')->loadMultiple($media_ids);
     foreach ($medias as $entity) {

--- a/src/AvPortalPullMedia.php
+++ b/src/AvPortalPullMedia.php
@@ -53,9 +53,10 @@ class AvPortalPullMedia {
     $medias = $this->entityTypeManager->getStorage('media')->loadMultiple($media_ids);
     foreach ($medias as $entity) {
       if ($entity->getSource()->getPluginDefinition()['provider'] === 'media_avportal') {
-        // Force the entity to update by marking the source field as changed.
+        // Force the entity to update the mapped fields from the source metadata
+        // by marking the source field as changed.
         // @see \Drupal\media\Entity\Media::prepareSave()
-        // @see \Drupal\media\Entity\Media::hasSourceFieldChanged
+        // @see \Drupal\media\Entity\Media::hasSourceFieldChanged()
         $entity->original = clone $entity;
         $source_field_name = $entity->getSource()->getConfiguration()['source_field'];
         $entity->original->get($source_field_name)->setValue(NULL);

--- a/src/AvPortalPullMedia.php
+++ b/src/AvPortalPullMedia.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_avportal;
+
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+
+/**
+ * Class of the service for fetching/refreshing AVPortal media entities.
+ */
+class AvPortalPullMedia {
+
+  use DependencySerializationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Logger service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerChannelFactory;
+
+  /**
+   * Creates AvPortalPullMedia objects.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_channel_factory
+   *   The logger channel factory.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerChannelFactoryInterface $logger_channel_factory) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->loggerChannelFactory = $logger_channel_factory;
+  }
+
+  /**
+   * Pull for updating existing media from AV Portal service.
+   *
+   * @param array $media_ids
+   *   Array of media ids.
+   */
+  public function pullAvPortalMedia(array $media_ids = NULL): void {
+    $medias = $this->entityTypeManager->getStorage('media')->loadMultiple($media_ids);
+    foreach ($medias as $media_entity) {
+      if ($media_entity->getSource()->getPluginDefinition()['provider'] === 'media_avportal') {
+        $media_entity->save();
+        $this->loggerChannelFactory->get('avportal_media')->notice('Media with ID %mid have been updated.', ['%mid' => $media_entity->id()]);
+      }
+    }
+  }
+
+}

--- a/src/AvPortalResource.php
+++ b/src/AvPortalResource.php
@@ -128,6 +128,13 @@ class AvPortalResource {
     if (isset($first_media_json['INT']['THUMB'])) {
       return UrlHelper::parse($first_media_json['INT']['THUMB'])['path'] ?? NULL;
     }
+
+    // We are trying to get a thumbnail of current default language.
+    // @todo Recheck this structure of language keys.
+    if (isset($first_media_json['EN/' . mb_strtoupper(\Drupal::languageManager()->getDefaultLanguage()->getId())]['THUMB'])) {
+      return UrlHelper::parse($first_media_json['EN/' . mb_strtoupper(\Drupal::languageManager()->getDefaultLanguage()->getId())]['THUMB'])['path'] ?? NULL;
+    }
+
     // We are trying to get a thumbnail
     // for a original language (usually English).
     elseif (isset($this->data['languages'][0]) && isset($first_media_json[$this->data['languages'][0]]['THUMB'])) {

--- a/src/AvPortalResource.php
+++ b/src/AvPortalResource.php
@@ -124,21 +124,18 @@ class AvPortalResource {
   protected function getVideoThumbnailUrl(): ?string {
     $first_media_json = reset($this->data['media_json']);
 
-    // We are trying to get a thumbnail of undefined language.
-    if (isset($first_media_json['INT']['THUMB'])) {
-      return UrlHelper::parse($first_media_json['INT']['THUMB'])['path'] ?? NULL;
-    }
+    $languages = [
+      'INT',
+      mb_strtoupper(\Drupal::languageManager()->getDefaultLanguage()->getId()),
+      'EN',
+      $this->data['languages'][0] ?? NULL,
+    ];
+    $languages = array_unique(array_filter($languages));
 
-    // We are trying to get a thumbnail of current default language.
-    // @todo Recheck this structure of language keys.
-    if (isset($first_media_json['EN/' . mb_strtoupper(\Drupal::languageManager()->getDefaultLanguage()->getId())]['THUMB'])) {
-      return UrlHelper::parse($first_media_json['EN/' . mb_strtoupper(\Drupal::languageManager()->getDefaultLanguage()->getId())]['THUMB'])['path'] ?? NULL;
-    }
-
-    // We are trying to get a thumbnail
-    // for a original language (usually English).
-    elseif (isset($this->data['languages'][0]) && isset($first_media_json[$this->data['languages'][0]]['THUMB'])) {
-      return UrlHelper::parse($first_media_json[$this->data['languages'][0]]['THUMB'])['path'] ?? NULL;
+    foreach ($languages as $langcode) {
+      if (isset($first_media_json[$langcode]['THUMB'])) {
+        return UrlHelper::parse($first_media_json[$langcode]['THUMB'])['path'] ?? NULL;
+      }
     }
 
     return NULL;

--- a/src/AvPortalResource.php
+++ b/src/AvPortalResource.php
@@ -86,7 +86,7 @@ class AvPortalResource {
       return $titles['EN'];
     }
     // Fallback to first available title,
-    // if even english language is not present.
+    // when english language is not present.
     if (count($titles) > 0 && $first_title = reset($titles)) {
       return is_string($first_title) ? $first_title : NULL;
     }
@@ -162,7 +162,7 @@ class AvPortalResource {
   }
 
   /**
-   * Returns all the resource data.
+   * Returns resource data.
    *
    * @return array
    *   The resource data.

--- a/src/AvPortalResource.php
+++ b/src/AvPortalResource.php
@@ -133,6 +133,8 @@ class AvPortalResource {
     elseif (isset($this->data['languages'][0]) && isset($first_media_json[$this->data['languages'][0]]['THUMB'])) {
       return UrlHelper::parse($first_media_json[$this->data['languages'][0]]['THUMB'])['path'] ?? NULL;
     }
+
+    return NULL;
   }
 
   /**
@@ -151,6 +153,8 @@ class AvPortalResource {
         return $media_json[$resolution]['PATH'];
       }
     }
+
+    return NULL;
   }
 
   /**

--- a/src/Commands/AvPortalCommands.php
+++ b/src/Commands/AvPortalCommands.php
@@ -65,7 +65,6 @@ class AvPortalCommands extends DrushCommands {
       'title' => $this->t('Update AVPortal medias.'),
       'progress_message' => '',
       'error_message' => $this->t('Error on updating avportal medias'),
-      // 'file' => drupal_get_path('module', 'locale') . '/locale.batch.inc',
     ];
 
     batch_set($batch);

--- a/src/Commands/AvPortalCommands.php
+++ b/src/Commands/AvPortalCommands.php
@@ -5,11 +5,11 @@ declare(strict_types = 1);
 namespace Drupal\media_avportal\Commands;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\media_avportal\AvPortalPullMedia;
+use Drupal\media_avportal\AvPortalMediaUpdater;
 use Drush\Commands\DrushCommands;
 
 /**
- * Class against drush commands for avportal medias.
+ * Drush integration for the Media AV Portal module.
  */
 class AvPortalCommands extends DrushCommands {
 
@@ -18,46 +18,49 @@ class AvPortalCommands extends DrushCommands {
   /**
    * The AV Portal pull media service.
    *
-   * @var \Drupal\media_avportal\AvPortalPullMedia
+   * @var \Drupal\media_avportal\AvPortalMediaUpdater
    */
-  protected $avPortalPullMedia;
+  protected $avPortalMediaUpdater;
 
   /**
    * Media AV Portal commands constructor.
    *
-   * @param \Drupal\media_avportal\AvPortalPullMedia $avportal_pull_media
+   * @param \Drupal\media_avportal\AvPortalMediaUpdater $avPortalMediaUpdater
    *   The service that update existing media.
    */
-  public function __construct(AvPortalPullMedia $avportal_pull_media) {
-    $this->avPortalPullMedia = $avportal_pull_media;
+  public function __construct(AvPortalMediaUpdater $avPortalMediaUpdater) {
+    parent::__construct();
+
+    $this->avPortalMediaUpdater = $avPortalMediaUpdater;
   }
 
   /**
-   * Update existing AvPortal Media entities with data from remote service.
+   * Refresh from the source all the mapped fields of AV Portal medias.
    *
    * @param array $options
    *   Command options.
    *
-   * @command media-avportal:pull-avportal-medias
+   * @command media-avportal:refresh-mapped-fields
    * @option mids A comma-separated list of media ids to update. If omitted, all av portal medias will be updated.
    * @validate-module-enabled media_avportal
    */
-  public function runPullAvportalMedias(array $options = ['mids' => self::OPT]): void {
+  public function runRefreshMappedFields(array $options = ['mids' => self::OPT]): void {
     $mids = $options['mids'] ? $options['mids'] : [];
 
     // Build operations for updating avportal medias with remote data.
     $operations = [];
     foreach ($mids as $mid) {
       $operations[] = [
-        [$this->avPortalPullMedia, 'pullAvPortalMedia'],
+        [$this->avPortalMediaUpdater, 'refreshMappedFields'],
         [$mid],
       ];
     }
 
-    $operations = $operations ? $operations : [[
-        [$this->avPortalPullMedia, 'pullAvPortalMedia'],
+    $operations = $operations ? $operations : [
+      [
+        [$this->avPortalMediaUpdater, 'refreshMappedFields'],
         [NULL],
-    ],
+      ],
     ];
 
     $batch = [

--- a/src/Commands/AvPortalCommands.php
+++ b/src/Commands/AvPortalCommands.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_avportal\Commands;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\media_avportal\AvPortalPullMedia;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Class against drush commands for avportal medias.
+ */
+class AvPortalCommands extends DrushCommands {
+
+  use StringTranslationTrait;
+
+  /**
+   * The AV Portal pull media service.
+   *
+   * @var \Drupal\media_avportal\AvPortalPullMedia
+   */
+  protected $avPortalPullMedia;
+
+  /**
+   * Media AV Portal commands constructor.
+   *
+   * @param \Drupal\media_avportal\AvPortalPullMedia $avportal_pull_media
+   *   The service that update existing media.
+   */
+  public function __construct(AvPortalPullMedia $avportal_pull_media) {
+    $this->avPortalPullMedia = $avportal_pull_media;
+  }
+
+  /**
+   * Update existing AvPortal Media entities with data from remote service.
+   *
+   * @param array $options
+   *   Command options.
+   *
+   * @command media-avportal:pull-avportal-medias
+   * @option mids A comma-separated list of media ids to update. If omitted, all av portal medias will be updated.
+   * @validate-module-enabled media_avportal
+   */
+  public function runPullAvportalMedias(array $options = ['mids' => self::OPT]): void {
+    $mids = $options['mids'] ? $options['mids'] : [];
+
+    // Build operations for updating avportal medias with remote data.
+    $operations = [];
+    foreach ($mids as $mid) {
+      $operations[] = [
+        [$this->avPortalPullMedia, 'pullAvPortalMedia'],
+        [$mid],
+      ];
+    }
+
+    $operations = $operations ? $operations : [[
+        [$this->avPortalPullMedia, 'pullAvPortalMedia'],
+        [NULL],
+    ],
+    ];
+
+    $batch = [
+      'operations' => $operations,
+      'title' => $this->t('Update AVPortal medias.'),
+      'progress_message' => '',
+      'error_message' => $this->t('Error on updating avportal medias'),
+      // 'file' => drupal_get_path('module', 'locale') . '/locale.batch.inc',
+    ];
+
+    batch_set($batch);
+
+    drush_backend_batch_process();
+  }
+
+}

--- a/tests/modules/media_avportal_mock/responses/resources/I-053547.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-053547.json
@@ -1,0 +1,358 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 8
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "content": "049",
+    "docs": [
+      {
+        "primary_key": "I-053547",
+        "sku": "I-053547",
+        "_id": "I-053547",
+        "ref": "I-053547",
+        "verifyid": "XJYTSDDQWTZNIMARMGUAMACZWGYXEDYQRZBOLRAD",
+        "childobjects": "4",
+        "id": 1454763,
+        "duration": "30",
+        "preview": "0",
+        "status_json": {
+          "shortcut": "PROD",
+          "id": 586,
+          "titles": {
+            "DE": "DE-IN DISTRIBUTION",
+            "EN": "IN DISTRIBUTION",
+            "FR": "EN DIFFUSION"
+          }
+        },
+        "genre_json": {
+          "id": 21,
+          "titles": {
+            "DE": "Werbung",
+            "EN": "Promotion",
+            "FR": "Promotion"
+          }
+        },
+        "genre": 21,
+        "cooperator_json": {
+          "I-053547-EN-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " EK - GD RTD"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - DG RTD"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - DG RTD"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          },
+          "I-053547-EN-2": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " EK - GD RTD"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - DG RTD"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - DG RTD"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          },
+          "I-053547-INT-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " EK - GD RTD"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - DG RTD"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - DG RTD"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          },
+          "I-053547-INT-2": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " EK - GD RTD"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - DG RTD"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - DG RTD"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " Medialab Technology"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          }
+        },
+        "titles_json": {
+          "FR": "Launch of the FP7: Clip 1 \"Ensemble\""
+        },
+        "summary_json": {
+          "FR": "Ces deux clips ont été produits à l'occasion du lancement du 7e programme cadre pour la recherche. Le Président de la Commission européenne, José Manuel Barroso, et d'autres Européens de premier plan, assisteront à une soirée sur la recherche européenne et ses réalisations, Les festivités débuteront par un spectacle centré sur un écran géant qui permettra de mettre en lumière la science et la recherche devant le siège du Conseil de l'UE et de la Commission européenne, en présence de la presse et de 500 invités du monde scientifique et politique. Ce spectacle sera suivi par une cérémonie au cours de laquelle les prix Descartes d'excellence scientifique et de communication scientifique seront décernés en présence de M. Janez Potocnik, le commissaire européen pour la recherche, et de Mme Annette Schavan, la ministre fédérale allemande chargée de l'éducation et de la recherche.Cette manifestation est organisée à la veille du Conseil européen de printemps de 2007. Il ne s'agit pas d'une coïncidence. La recherche joue indéniablement un rôle central dans la mise en place et le maintien d'une Europe compétitive et viable. L'organisation de cet événement parallèlement au traditionnel Conseil européen de printemps faisant suite au Conseil de Lisbonne permet de donner un signal fort quant à l'importance que l'UE accorde à la recherche."
+        },
+        "prod_loc_json": {
+          "id": 74,
+          "titles": {
+            "DE": "Paris",
+            "EN": "Paris",
+            "FR": "Paris"
+          }
+        },
+        "productiondate": "200703060000",
+        "previewCode": "",
+        "shootstartdate": "2007",
+        "shootenddate": "2007",
+        "mvtt_json": {
+          "I-053547": []
+        },
+        "msrt_json": {
+          "I-053547": []
+        },
+        "links_json": {
+          "URL": [
+            "http:\/\/www.ec.europa.eu\/research\/fp7\/index_en.cfm"
+          ]
+        },
+        "project": "0",
+        "project_json": {
+          "value": {
+            "EN": "[0] Migration",
+            "FR": "[0] Migration"
+          },
+          "id": "0"
+        },
+        "thesgen_json": [
+          {
+            "id": 421,
+            "value": {
+              "DE": "Forschung und Entwicklung",
+              "EN": "Research and development",
+              "FR": "Recherche et développement"
+            }
+          },
+          {
+            "id": 1357,
+            "value": {
+              "DE": "Rahmenprogramm für Forschung und technologische Entwicklung",
+              "EN": "Framework programme for research and technical development",
+              "FR": "Programme-cadre pour la recherche et le développement technologique"
+            }
+          }
+        ],
+        "thes_gen": [
+          421,
+          1357
+        ],
+        "location_json": [
+          {
+            "id": 202,
+            "value": {
+              "DE": "Brüssel - Rond-Point Schuman",
+              "EN": "Brussels - Rond Point Schuman",
+              "FR": "Bruxelles - Rond-Point Schuman"
+            }
+          }
+        ],
+        "thes_loc": [
+          202
+        ],
+        "copyright_json": {
+          "year": "2007",
+          "holders": {
+            "DE": [
+              "Europäische Gemeinschaften"
+            ],
+            "EN": [
+              "European Communities"
+            ],
+            "FR": [
+              "Communautés européennes"
+            ]
+          }
+        },
+        "search_date": "2007-03-06T05:03:00Z",
+        "audioorder_json": [
+          {
+            "INT": {
+              "ASPECT": {
+                "4:3": "TRUE"
+              },
+              "TEXT": "Original"
+            }
+          }
+        ],
+        "hasAudio": "1",
+        "languages": [
+          "INT"
+        ],
+        "mediaorder_json": [
+          {
+            "INT": {
+              "SUPPORTS": "WEB",
+              "ASPECT": {
+                "4:3": "TRUE"
+              },
+              "TEXT": "Original"
+            }
+          }
+        ],
+        "hasMedia": "1",
+        "media_json": {
+          "4:3": {
+            "INT": {
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/053547\/MP3_I053547INT1.mp3?latest=0000102624",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/053547\/THUMB_I053547INT1.jpg?latest=0000102626",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/053547\/LR_I053547INT1.mp4?latest=0000102620",
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/053547\/THUMB_M_I053547INT1.jpg?latest=0000102628"
+            }
+          }
+        },
+        "time": "200703060000",
+        "views": 12,
+        "rating": "5",
+        "dg": 404,
+        "dg_json": {
+          "shortcut": "COMM",
+          "id": 404,
+          "titles": {
+            "DE": "Generaldirektion für Kommunikation",
+            "EN": "Directorate-General for Communication",
+            "FR": "Direction générale de la communication"
+          }
+        },
+        "type": "VIDEO",
+        "theme": [
+          817,
+          775,
+          756
+        ],
+        "series_json": [],
+        "_version_": 1632779145508290560,
+        "popularity": 0,
+        "timestamp": "2019-05-06T10:45:35.408Z"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/resources/I-056847.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-056847.json
@@ -1,0 +1,240 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 9
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "content": "050",
+    "docs": [
+      {
+        "primary_key": "I-056847",
+        "sku": "I-056847",
+        "_id": "I-056847",
+        "ref": "I-056847",
+        "verifyid": "CHFZJPUOMFSFQPWJJNFGQZOUONUUQZUWEGZDDJFH",
+        "childobjects": "1",
+        "id": 1457972,
+        "duration": "241",
+        "preview": "0",
+        "status_json": {
+          "shortcut": "PROD",
+          "id": 586,
+          "titles": {
+            "DE": "DE-IN DISTRIBUTION",
+            "EN": "IN DISTRIBUTION",
+            "FR": "EN DIFFUSION"
+          }
+        },
+        "genre_json": {
+          "id": 42,
+          "titles": {
+            "DE": "Clip",
+            "EN": "Clip",
+            "FR": "Clip"
+          }
+        },
+        "genre": 42,
+        "cooperator_json": {
+          "I-056847-EN-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " EK - GD ENTR"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - DG ENTR"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - DG ENTR"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Mostra Communication"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " Mostra Communication"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " Mostra Communication"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          }
+        },
+        "titles_json": {
+          "FR": "Space and You (short version)"
+        },
+        "summary_json": {
+          "FR": "L'espace joue dans notre quotidien un rôle plus important qu'on ne l'imagine. Du match de football aux prévisions météorologiques, les satellites spatiaux d'Europe joue un rôle indispensable dans le fonctionnement de notre société. Ajoutez à cela l'importance de l'information satellitaire au regard des préoccupations sociales au sens large, telles que les fluctuations du changement climatique et la planification stratégique des opérations humanitaires et vous vous rendrez vite compte de l'étendue et de l'influence des technologies et des systèmes spatiaux.",
+          "EN": "Space plays more of a role in our everyday lives than we might imagine. From watching our favourite football matches to weather forecasting, Europe's space satellites play an indispensable role in the day-to-day functioning of our society. Add this to the importance of satellite information with regards to larger societal concerns such as fluctuations in climate change and strategic planning for humanitarian operations, and suddenly, the scope and significance of space systems and space-based technologies are brought into focus."
+        },
+        "productiondate": "200803310000",
+        "previewCode": "",
+        "shootstartdate": "200803",
+        "shootenddate": "200803",
+        "mvtt_json": {
+          "I-056847": []
+        },
+        "msrt_json": {
+          "I-056847": []
+        },
+        "project": "0",
+        "project_json": {
+          "value": {
+            "EN": "[0] Migration",
+            "FR": "[0] Migration"
+          },
+          "id": "0"
+        },
+        "thesgen_json": [
+          {
+            "id": 833,
+            "value": {
+              "DE": "Neue Informations- und Kommunikationstechnologien",
+              "EN": "New information and communication technologies",
+              "FR": "Nouvelles technologies de l'information et de la communication"
+            }
+          },
+          {
+            "id": 1368,
+            "value": {
+              "DE": "Galileo",
+              "EN": "Galileo",
+              "FR": "Galileo"
+            }
+          },
+          {
+            "id": 1859,
+            "value": {
+              "DE": "Globales Satellitennavigationssystem",
+              "EN": "Global satellite navigation system",
+              "FR": "Système global de navigation par satellite"
+            }
+          },
+          {
+            "id": 3510,
+            "value": {
+              "DE": "***NULL_DE_1354174060_TIC",
+              "EN": "TIC",
+              "FR": "ICT"
+            }
+          },
+          {
+            "id": 6366,
+            "value": {
+              "DE": "NITK",
+              "EN": "NITC",
+              "FR": "NTIC"
+            }
+          }
+        ],
+        "thes_gen": [
+          833,
+          1368,
+          1859,
+          3510,
+          6366
+        ],
+        "location_json": [],
+        "copyright_json": {
+          "year": "2008",
+          "holders": {
+            "DE": [
+              "Europäische Gemeinschaften"
+            ],
+            "EN": [
+              "European Communities"
+            ],
+            "FR": [
+              "Communautés européennes"
+            ]
+          }
+        },
+        "search_date": "2008-03-31T05:03:00Z",
+        "audioorder_json": [
+          {
+            "EN": {
+              "ASPECT": {
+                "4:3": "TRUE"
+              },
+              "TEXT": "English"
+            }
+          }
+        ],
+        "hasAudio": "1",
+        "languages": [
+          "EN"
+        ],
+        "mediaorder_json": [
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "ASPECT": {
+                "4:3": "TRUE"
+              },
+              "TEXT": "English"
+            }
+          }
+        ],
+        "hasMedia": "1",
+        "media_json": {
+          "4:3": {
+            "EN": {
+              "MP3": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/056847\/MP3_I056847EN1.mp3?latest=0000102402",
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/056847\/THUMB_I056847EN1.jpg?latest=0000102404",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/056847\/LR_I056847EN1.mp4?latest=0000102398",
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/07\/056847\/THUMB_M_I056847EN1.jpg?latest=0000102406"
+            }
+          }
+        },
+        "time": "200803310000",
+        "views": 12,
+        "rating": "5",
+        "dg": 404,
+        "dg_json": {
+          "shortcut": "COMM",
+          "id": 404,
+          "titles": {
+            "DE": "Generaldirektion für Kommunikation",
+            "EN": "Directorate-General for Communication",
+            "FR": "Direction générale de la communication"
+          }
+        },
+        "type": "VIDEO",
+        "theme": [
+          773,
+          755,
+          756,
+          833,
+          811,
+          764,
+          795,
+          825
+        ],
+        "series_json": [],
+        "_version_": 1632782050182299648,
+        "popularity": 0,
+        "timestamp": "2019-05-06T11:31:45.514Z"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_mock/responses/resources/I-129872.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-129872.json
@@ -1,0 +1,461 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 46
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "content": "050",
+    "docs": [
+      {
+        "primary_key": "I-129872",
+        "sku": "I-129872",
+        "_id": "I-129872",
+        "ref": "I-129872",
+        "verifyid": "KZVMWLACJHGFNRAKANSHLSSKSVPKTZVUMVYXXMYW",
+        "childobjects": "4",
+        "id": 1530673,
+        "duration": "38",
+        "preview": "0",
+        "status_json": {
+          "shortcut": "PROD",
+          "id": 586,
+          "titles": {
+            "DE": "DE-IN DISTRIBUTION",
+            "EN": "IN DISTRIBUTION",
+            "FR": "EN DIFFUSION"
+          }
+        },
+        "genre_json": {
+          "id": 42,
+          "titles": {
+            "DE": "Clip",
+            "EN": "Clip",
+            "FR": "Clip"
+          }
+        },
+        "genre": 42,
+        "cooperator_json": {
+          "I-129872-EN\/FR-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Europäische Kommission - Audiovisueller Dienst"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - Audiovisual Service"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - Service audiovisuel"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "DIRECTOR": {
+              "DE": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Regisseur"
+              },
+              "EN": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Director"
+              },
+              "FR": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Réalisateur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          },
+          "I-129872-EN-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Europäische Kommission - Audiovisueller Dienst"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - Audiovisual Service"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - Service audiovisuel"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "DIRECTOR": {
+              "DE": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Regisseur"
+              },
+              "EN": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Director"
+              },
+              "FR": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Réalisateur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          },
+          "I-129872-EN\/DE-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Europäische Kommission - Audiovisueller Dienst"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - Audiovisual Service"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - Service audiovisuel"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "DIRECTOR": {
+              "DE": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Regisseur"
+              },
+              "EN": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Director"
+              },
+              "FR": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Réalisateur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          },
+          "I-129872-INT-1": {
+            "PRODUCER": {
+              "DE": {
+                "coop": [
+                  " Europäische Kommission - Audiovisueller Dienst"
+                ],
+                "title": "Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " EC - Audiovisual Service"
+                ],
+                "title": "Producer"
+              },
+              "FR": {
+                "coop": [
+                  " CE - Service audiovisuel"
+                ],
+                "title": "Producteur"
+              }
+            },
+            "DIRECTOR": {
+              "DE": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Regisseur"
+              },
+              "EN": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Director"
+              },
+              "FR": {
+                "coop": [
+                  "Catherine Vandezande"
+                ],
+                "title": "Réalisateur"
+              }
+            },
+            "EXECUTIVE_PRODUCER": {
+              "DE": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Ausführender Produzent"
+              },
+              "EN": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Executive producer"
+              },
+              "FR": {
+                "coop": [
+                  " ALL TV"
+                ],
+                "title": "Producteur exécutif"
+              }
+            }
+          }
+        },
+        "titles_json": {
+          "FR": "Corps de solidarité européen - Teaser 2",
+          "EN": "European Solidarity Corps - Teaser 2"
+        },
+        "summary_json": {
+          "FR": "Ceci est une vidéo promotionnelle pour le Corps de solidarité Européen.",
+          "EN": "This is a promotional video for the European Solidarity Corps."
+        },
+        "prod_loc_json": {
+          "id": 2,
+          "titles": {
+            "DE": "Brüssel",
+            "EN": "Brussels",
+            "FR": "Bruxelles"
+          }
+        },
+        "productiondate": "201612070000",
+        "previewCode": "",
+        "shootstartdate": "",
+        "shootenddate": "",
+        "mvtt_json": {
+          "I-129872": []
+        },
+        "msrt_json": {
+          "I-129872": []
+        },
+        "project": "26296",
+        "project_json": {
+          "value": {
+            "EN": "Launch of the European Solidarity Corps",
+            "FR": "Lancement du Corps de solidarité européen"
+          },
+          "id": "26296"
+        },
+        "thesgen_json": [
+          {
+            "id": 1663,
+            "value": {
+              "DE": "Solidaritätsfonds der Europäischen Union",
+              "EN": "European Union Solidarity Fund",
+              "FR": "Fonds de solidarité de l'Union européenne"
+            }
+          },
+          {
+            "id": 5851,
+            "value": {
+              "DE": "Beschäftigung, Wachstum und Investitionen <Politische Priorität>",
+              "EN": "Jobs, Growth and Investment <Political priority>",
+              "FR": "Emploi, croissance et investissement <priorité politique>"
+            }
+          },
+          {
+            "id": 5857,
+            "value": {
+              "DE": "Justiz und Grundrechte <Politische Priorität>",
+              "EN": "Justice and Fundamental Rights <Political priority>",
+              "FR": "Justice et droits fondamentaux <priorité politique>"
+            }
+          },
+          {
+            "id": 6197,
+            "value": {
+              "DE": "Europäisches Solidaritätskorps",
+              "EN": "European Solidarity Corps",
+              "FR": "Corps européen de solidarité"
+            }
+          }
+        ],
+        "thes_gen": [
+          1663,
+          5851,
+          5857,
+          6197
+        ],
+        "location_json": [],
+        "copyright_json": {
+          "year": "2016",
+          "holders": {
+            "DE": [
+              "Europäische Union"
+            ],
+            "EN": [
+              "European Union"
+            ],
+            "FR": [
+              "Union européenne"
+            ]
+          }
+        },
+        "search_date": "2016-12-07T05:12:00Z",
+        "languages": [
+          "EN",
+          "EN/DE",
+          "EN/FR"
+        ],
+        "mediaorder_json": [
+          {
+            "EN": {
+              "SUPPORTS": "WEB",
+              "ASPECT": {
+                "16:9": "TRUE"
+              },
+              "TEXT": "English"
+            }
+          },
+          {
+            "EN\/DE": {
+              "SUPPORTS": "WEB",
+              "ASPECT": {
+                "16:9": "TRUE"
+              },
+              "TEXT": "English (Deutsch subtitle)"
+            }
+          },
+          {
+            "EN\/FR": {
+              "SUPPORTS": "WEB",
+              "ASPECT": {
+                "16:9": "TRUE"
+              },
+              "TEXT": "English (Français subtitle)"
+            }
+          }
+        ],
+        "hasMedia": "1",
+        "media_json": {
+          "16:9": {
+            "EN\/FR": {
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/THUMB_I129872ENFR1W.jpg?latest=0004825500",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/HD_I129872ENFR1W.mp4?latest=0004825506",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/LR_I129872ENFR1W.mp4?latest=0004825504",
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/THUMB_M_I129872ENFR1W.jpg?latest=0004825502"
+            },
+            "EN\/DE": {
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/THUMB_I129872ENDE1W.jpg?latest=0004825510",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/HD_I129872ENDE1W.mp4?latest=0004825516",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/LR_I129872ENDE1W.mp4?latest=0004825514",
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/THUMB_M_I129872ENDE1W.jpg?latest=0004825512"
+            },
+            "EN": {
+              "IMAGE": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/THUMB_I129872EN1W.jpg?latest=0004806152",
+              "HDMP4": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/HD_I129872EN1W.mp4?latest=0004806158",
+              "LR": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/LR_I129872EN1W.mp4?latest=0004806156",
+              "THUMB": "http:\/\/defiris.ec.streamcloud.be\/findmedia\/12\/129872\/THUMB_M_I129872EN1W.jpg?latest=0004806154"
+            }
+          }
+        },
+        "time": "201612070000",
+        "views": 12,
+        "rating": "5",
+        "dg": 404,
+        "dg_json": {
+          "shortcut": "COMM",
+          "id": 404,
+          "titles": {
+            "DE": "Generaldirektion für Kommunikation",
+            "EN": "Directorate-General for Communication",
+            "FR": "Direction générale de la communication"
+          }
+        },
+        "type": "VIDEO",
+        "theme": [
+          796,
+          762
+        ],
+        "series_json": [],
+        "_version_": 1632782646247424000,
+        "popularity": 0,
+        "timestamp": "2019-05-06T11:41:13.991Z"
+      }
+    ]
+  }
+}

--- a/tests/modules/media_avportal_test/config/install/field.field.media.av_portal_photo.oe_media_avportal_photo.yml
+++ b/tests/modules/media_avportal_test/config/install/field.field.media.av_portal_photo.oe_media_avportal_photo.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.oe_media_avportal_photo
+    - media.type.av_portal_photo
+id: media.av_portal_video.oe_media_avportal_photo
+field_name: oe_media_avportal_photo
+entity_type: media
+bundle: av_portal_photo
+label: 'Media AV Portal Photo'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/tests/modules/media_avportal_test/config/install/field.field.media.av_portal_video.oe_media_avportal_video.yml
+++ b/tests/modules/media_avportal_test/config/install/field.field.media.av_portal_video.oe_media_avportal_video.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.oe_media_avportal_video
+    - media.type.av_portal_video
+id: media.av_portal_video.oe_media_avportal_video
+field_name: oe_media_avportal_video
+entity_type: media
+bundle: av_portal_video
+label: 'Media AV Portal Video'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/tests/modules/media_avportal_test/config/install/field.storage.media.oe_media_avportal_photo.yml
+++ b/tests/modules/media_avportal_test/config/install/field.storage.media.oe_media_avportal_photo.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.oe_media_avportal_photo
+field_name: oe_media_avportal_photo
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/media_avportal_test/config/install/field.storage.media.oe_media_avportal_video.yml
+++ b/tests/modules/media_avportal_test/config/install/field.storage.media.oe_media_avportal_video.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.oe_media_avportal_video
+field_name: oe_media_avportal_video
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/media_avportal_test/config/install/media.type.av_portal_photo.yml
+++ b/tests/modules/media_avportal_test/config/install/media.type.av_portal_photo.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_avportal
+id: av_portal_photo
+label: 'AV Portal Photo'
+description: 'Remote photo from <em>AV Portal</em> service.'
+source: media_avportal_photo
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  thumbnails_directory: 'public://media_avportal_thumbnails'
+  source_field: oe_media_avportal_photo
+field_map:
+  title: name

--- a/tests/modules/media_avportal_test/config/install/media.type.av_portal_video.yml
+++ b/tests/modules/media_avportal_test/config/install/media.type.av_portal_video.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_avportal
+id: av_portal_video
+label: 'AV Portal Video'
+description: 'Remote video from <em>AV Portal</em> service.'
+source: media_avportal_video
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  thumbnails_directory: 'public://media_avportal_thumbnails'
+  source_field: oe_media_avportal_video
+field_map:
+  title: name

--- a/tests/modules/media_avportal_test/media_avportal_test.info.yml
+++ b/tests/modules/media_avportal_test/media_avportal_test.info.yml
@@ -1,0 +1,4 @@
+name: Media AV Portal Test
+description: Provides configuration media bundles for testing purpose.
+core: 8.x
+type: module

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -298,7 +298,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
    */
   protected function getVideoFixtures(): array {
     return [
-      [
+      'Video without thumbnail and title' => [
         'input' => [
           'urls' => [
             'https://audiovisual.ec.europa.eu/en/video/I-056847',
@@ -308,7 +308,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
           'title' => 'Space and You (short version)',
         ],
       ],
-      [
+      'Video with no title' => [
         'input' => [
           'urls' => [
             'https://audiovisual.ec.europa.eu/en/video/I-053547',
@@ -318,7 +318,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
           'title' => 'Launch of the FP7: Clip 1 "Ensemble"',
         ],
       ],
-      [
+      'Video with no thumbnail' => [
         'input' => [
           'urls' => [
             'https://audiovisual.ec.europa.eu/en/video/I-129872',

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -16,7 +16,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'node',
     'field_ui',
@@ -114,6 +114,21 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $page->pressButton('Save');
 
     $assert_session->pageTextContains('Invalid URL format specified.');
+
+    // Test creating a media content from different URLs and check field values.
+    foreach ($this->getVideoFixtures() as $test) {
+      foreach ($test['input']['urls'] as $url) {
+        // Create a media content with a valid reference.
+        $this->drupalGet('media/add/media_av_portal_video');
+        $page->fillField('Media AV Portal Video', $url);
+        $page->pressButton('Save');
+
+        $page->clickLink($test['expect']['title']);
+        $image_url = $assert_session->elementExists('css', '.field--name-thumbnail img')->getAttribute('src');
+        // Make sure that we have a thumbnail.
+        $this->assertNotContains('generic/no-thumbnail.png', $image_url);
+      }
+    }
   }
 
   /**
@@ -276,6 +291,44 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     $image_url = $picture->find('css', 'img.avportal-photo')->getAttribute('src');
     $this->assertContains('ec.europa.eu/avservices/avs/files/video6/repository/prod/photo/store/', $image_url);
     $this->assertContains('P038924-352937.jpg', $image_url);
+  }
+
+  /**
+   * Fixtures of data for testing rendering of creating and rendering of.
+   */
+  protected function getVideoFixtures(): array {
+    return [
+      [
+        'input' => [
+          'urls' => [
+            'https://audiovisual.ec.europa.eu/en/video/I-056847',
+          ],
+        ],
+        'expect' => [
+          'title' => 'Space and You (short version)',
+        ],
+      ],
+      [
+        'input' => [
+          'urls' => [
+            'https://audiovisual.ec.europa.eu/en/video/I-053547',
+          ],
+        ],
+        'expect' => [
+          'title' => 'Launch of the FP7: Clip 1 "Ensemble"',
+        ],
+      ],
+      [
+        'input' => [
+          'urls' => [
+            'https://audiovisual.ec.europa.eu/en/video/I-129872',
+          ],
+        ],
+        'expect' => [
+          'title' => 'European Solidarity Corps - Teaser 2',
+        ],
+      ],
+    ];
   }
 
 }

--- a/tests/src/Kernel/AvPortalPullMediaTest.php
+++ b/tests/src/Kernel/AvPortalPullMediaTest.php
@@ -131,7 +131,8 @@ class AvPortalPullMediaTest extends MediaKernelTestBase {
 
     $outdated_media_data = $media_storage->load($outdated_media->id())->toArray();
     $this->assertEquals('European Solidarity Corps - Teaser 2', $outdated_media_data['name'][0]['value']);
-    // The correct thumbnail has been associated back.
+    // The correct thumbnail has been associated back (file is similar so a
+    // a new one is not created).
     $this->assertEquals($outdated_media_thumbnail->id(), $outdated_media_data['thumbnail'][0]['target_id']);
   }
 

--- a/tests/src/Kernel/AvPortalPullMediaTest.php
+++ b/tests/src/Kernel/AvPortalPullMediaTest.php
@@ -48,9 +48,9 @@ class AvPortalPullMediaTest extends MediaKernelTestBase {
   }
 
   /**
-   * Tests work of AvPortal Pull media service.
+   * Tests the media updater service.
    */
-  public function testAvPortalPullMediaService(): void {
+  public function testAvPortalMediaUpdaterService(): void {
     // When a media is created and it has no thumbnail, a default one is used.
     // Create a file to use as default thumbnail.
     // @see \Drupal\media\Entity\Media::loadThumbnail()
@@ -120,7 +120,7 @@ class AvPortalPullMediaTest extends MediaKernelTestBase {
     $this->assertEquals($thumbnail->id(), $outdated_media_data['thumbnail'][0]['target_id']);
 
     // Run the import.
-    \Drupal::service('media_avportal.avportal_pull_media')->pullAvPortalMedia();
+    \Drupal::service('media_avportal.media_updater')->refreshMappedFields();
 
     // Verify that the media entities have been updated.
     $media_storage->resetCache();

--- a/tests/src/Kernel/AvPortalPullMediaTest.php
+++ b/tests/src/Kernel/AvPortalPullMediaTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\media_avportal\src\Kernel;
 
+use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
 use Drupal\Tests\media\Kernel\MediaKernelTestBase;
 
@@ -50,42 +51,88 @@ class AvPortalPullMediaTest extends MediaKernelTestBase {
    * Tests work of AvPortal Pull media service.
    */
   public function testAvPortalPullMediaService(): void {
+    // When a media is created and it has no thumbnail, a default one is used.
+    // Create a file to use as default thumbnail.
+    // @see \Drupal\media\Entity\Media::loadThumbnail()
+    file_put_contents('public://default-thumbnail.jpg', '');
+    $thumbnail = File::create([
+      'uri' => 'public://default-thumbnail.jpg',
+    ]);
+    $thumbnail->save();
 
-    /** @var \Drupal\Core\Entity\Sql\SqlContentEntityStorage $media_storage */
-    $media_storage = $this->container->get('entity_type.manager')->getStorage('media');
-
-    $media = Media::create([
-      'name' => 'random',
+    $empty_media = Media::create([
       'oe_media_avportal_video' => 'I-056847',
       'bundle' => 'av_portal_video',
     ]);
-
-    $media->save();
-
-    // Emulate media with empty name and thumbnail.
+    $empty_media->save();
+    // Store the correct thumbnail to have a comparison later.
+    $empty_media_thumbnail = $empty_media->get('thumbnail')->entity;
+    // Simulate that the media was created without name and thumbnail.
     \Drupal::database()->update('media_field_data')
       ->fields([
         'name' => NULL,
         'thumbnail__target_id' => NULL,
-      ])->execute();
+      ])
+      ->condition('mid', $empty_media->id())
+      ->execute();
     \Drupal::database()->update('media_field_revision')
       ->fields([
         'name' => NULL,
         'thumbnail__target_id' => NULL,
-      ])->execute();
+      ])
+      ->condition('mid', $empty_media->id())
+      ->execute();
 
+    // Create another entity with an outdated thumbnail.
+    $outdated_media = Media::create([
+      'oe_media_avportal_video' => 'I-129872',
+      'bundle' => 'av_portal_video',
+    ]);
+    $outdated_media->save();
+    // Store the correct thumbnail.
+    $outdated_media_thumbnail = $outdated_media->get('thumbnail')->entity;
+    \Drupal::database()->update('media_field_data')
+      ->fields([
+        'thumbnail__target_id' => $thumbnail->id(),
+      ])
+      ->condition('mid', $outdated_media->id())
+      ->execute();
+    \Drupal::database()->update('media_field_revision')
+      ->fields([
+        'thumbnail__target_id' => $thumbnail->id(),
+      ])
+      ->condition('mid', $outdated_media->id())
+      ->execute();
+
+    /** @var \Drupal\Core\Entity\Sql\SqlContentEntityStorage $media_storage */
+    $media_storage = $this->container->get('entity_type.manager')->getStorage('media');
     $media_storage->resetCache();
-    $media = $media_storage->load($media->id())->toArray();
-    $this->assertEqual($media['name'], []);
-    $this->assertEqual($media['thumbnail'][0]['target_id'], NULL);
 
+    // Convert the entity to an array. This will extract the current values and
+    // avoid the Media class to use fallbacks for the title.
+    $empty_media_data = $media_storage->load($empty_media->id())->toArray();
+    // Verify that the test data has been successfully altered.
+    $this->assertEquals([], $empty_media_data['name']);
+    $this->assertNull($empty_media_data['thumbnail'][0]['target_id']);
+
+    $outdated_media_data = $media_storage->load($outdated_media->id())->toArray();
+    $this->assertEquals('European Solidarity Corps - Teaser 2', $outdated_media_data['name'][0]['value']);
+    $this->assertEquals($thumbnail->id(), $outdated_media_data['thumbnail'][0]['target_id']);
+
+    // Run the import.
     \Drupal::service('media_avportal.avportal_pull_media')->pullAvPortalMedia();
 
+    // Verify that the media entities have been updated.
     $media_storage->resetCache();
-    $media = $media_storage->load($media['mid'][0]['value'])->toArray();
+    $empty_media = $media_storage->load($empty_media->id());
+    $empty_media_data = $empty_media->toArray();
+    $this->assertEquals('Space and You (short version)', $empty_media_data['name'][0]['value']);
+    $this->assertEquals($empty_media_thumbnail->id(), $empty_media_data['thumbnail'][0]['target_id']);
 
-    $this->assertEqual($media['name'][0]['value'], 'Space and You (short version)');
-    $this->assertNotEmpty($media['thumbnail'][0]['target_id']);
+    $outdated_media_data = $media_storage->load($outdated_media->id())->toArray();
+    $this->assertEquals('European Solidarity Corps - Teaser 2', $outdated_media_data['name'][0]['value']);
+    // The correct thumbnail has been associated back.
+    $this->assertEquals($outdated_media_thumbnail->id(), $outdated_media_data['thumbnail'][0]['target_id']);
   }
 
 }

--- a/tests/src/Kernel/AvPortalPullMediaTest.php
+++ b/tests/src/Kernel/AvPortalPullMediaTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\media_avportal\src\Kernel;
+
+use Drupal\media\Entity\Media;
+use Drupal\Tests\media\Kernel\MediaKernelTestBase;
+
+/**
+ * Tests the AvPortalPullMediaTest.
+ */
+class AvPortalPullMediaTest extends MediaKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'remote_stream_wrapper',
+    'media_avportal',
+    'media_avportal_mock',
+    'media_avportal_test',
+    'media',
+    'field',
+    'text',
+    'image',
+    'user',
+    'file',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installConfig([
+      'field',
+      'text',
+      'image',
+      'user',
+      'file',
+      'media_avportal',
+      'media_avportal_test',
+      'media',
+    ]);
+  }
+
+  /**
+   * Tests work of AvPortal Pull media service.
+   */
+  public function testAvPortalPullMediaService(): void {
+
+    /** @var \Drupal\Core\Entity\Sql\SqlContentEntityStorage $media_storage */
+    $media_storage = $this->container->get('entity_type.manager')->getStorage('media');
+
+    $media = Media::create([
+      'name' => 'random',
+      'oe_media_avportal_video' => 'I-056847',
+      'bundle' => 'av_portal_video',
+    ]);
+
+    $media->save();
+
+    // Emulate media with empty name and thumbnail.
+    \Drupal::database()->update('media_field_data')
+      ->fields([
+        'name' => NULL,
+        'thumbnail__target_id' => NULL,
+      ])->execute();
+    \Drupal::database()->update('media_field_revision')
+      ->fields([
+        'name' => NULL,
+        'thumbnail__target_id' => NULL,
+      ])->execute();
+
+    $media_storage->resetCache();
+    $media = $media_storage->load($media->id())->toArray();
+    $this->assertEqual($media['name'], []);
+    $this->assertEqual($media['thumbnail'][0]['target_id'], NULL);
+
+    \Drupal::service('media_avportal.avportal_pull_media')->pullAvPortalMedia();
+
+    $media_storage->resetCache();
+    $media = $media_storage->load($media['mid'][0]['value'])->toArray();
+
+    $this->assertEqual($media['name'][0]['value'], 'Space and You (short version)');
+    $this->assertNotEmpty($media['thumbnail'][0]['target_id']);
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-2165

### Description

Some videos have a different response format, thus the current code cannot retrieve the correct metadata from them. Quite a few examples were found by AMPATZIS Ioannis:

no thumbnail: https://audiovisual.ec.europa.eu/en/video/I-129872 https://audiovisual.ec.europa.eu/en/video/I-098040
no title: https://audiovisual.ec.europa.eu/en/video/I-053547 https://audiovisual.ec.europa.eu/en/video/I-001464
no thumbnail AND title: https://audiovisual.ec.europa.eu/en/video/I-056847
The reason seems a different format for the json response. Scope of the ticket is to cover these cases.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

