### PR TITLE
Remove the section about disabling the page cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,32 +161,6 @@ To run the phpunit tests:
 docker-compose exec web ./vendor/bin/phpunit
 ```
 
-### Disable Drupal 8 caching
-
-Manually disabling Drupal 8 caching is a laborious process that is well described [here][10].
-
-Alternatively you can use the following Drupal Console commands to disable/enable Drupal 8 caching:
-
-```bash
-./vendor/bin/drupal site:mode dev  # Disable all caches.
-./vendor/bin/drupal site:mode prod # Enable all caches.
-```
-
-Note: to fully disable Twig caching the following additional manual steps are required:
-
-1. Open `./build/sites/default/services.yml`
-2. Set `cache: false` in `twig.config:` property. E.g.:
-
-```yaml
-parameters:
- twig.config:
-   cache: false
-```
-
-3. Rebuild Drupal cache: `./vendor/bin/drush cr`
-
-This is due to the following [Drupal Console issue][11].
-
 ## Contributing
 
 Please read [the full documentation](https://github.com/openeuropa/openeuropa) for details on our code of conduct, and the process for submitting pull requests to us.


### PR DESCRIPTION
Fixes #4

### Description

The README contains a section about having to disable the page cache for using the module. This is not required, ref #4.

### Change log

- Removed: misleading section in the documentation that mentioned the need to disable the page cache.
