### PR TITLE
OPENEUROPA-2716: Some of AV Portal videos are not working.

### DIFF
--- a/src/AvPortalClient.php
+++ b/src/AvPortalClient.php
@@ -47,7 +47,7 @@ class AvPortalClient implements AvPortalClientInterface {
   public function query(array $options = []): ?array {
     $options += [
       'fl' => 'type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json',
-      'hasmedia' => 1,
+      'hasMedia' => 1,
       'wt' => 'json',
       'index' => 1,
       'pagesize' => 15,

--- a/tests/modules/media_avportal_mock/responses/all-default.json
+++ b/tests/modules/media_avportal_mock/responses/all-default.json
@@ -5,7 +5,7 @@
     "params": {
       "pagesize": "15",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0099",

--- a/tests/modules/media_avportal_mock/responses/resources/I-162747.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-162747.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "ref": "I-162747",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0099",

--- a/tests/modules/media_avportal_mock/responses/resources/I-163162.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-163162.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "ref": "I-163162",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0099",

--- a/tests/modules/media_avportal_mock/responses/resources/not-found.json
+++ b/tests/modules/media_avportal_mock/responses/resources/not-found.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "ref": "I-12345678987654321",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0100",

--- a/tests/modules/media_avportal_mock/responses/searches/all-empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/all-empty.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "ref": "I-12345678987654321",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "kwgg": "",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",

--- a/tests/modules/media_avportal_mock/responses/searches/all-europe.json
+++ b/tests/modules/media_avportal_mock/responses/searches/all-europe.json
@@ -5,7 +5,7 @@
     "params": {
       "pagesize": "15",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "kwgg": "europe",
       "proxy": "true",

--- a/tests/modules/media_avportal_mock/responses/searches/photo-empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/photo-empty.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "ref": "I-12345678987654321",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "kwgg": "",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",

--- a/tests/modules/media_avportal_mock/responses/searches/video-empty.json
+++ b/tests/modules/media_avportal_mock/responses/searches/video-empty.json
@@ -6,7 +6,7 @@
       "pagesize": "15",
       "ref": "I-12345678987654321",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "kwgg": "",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",

--- a/tests/modules/media_avportal_mock/responses/searches/video-europe.json
+++ b/tests/modules/media_avportal_mock/responses/searches/video-europe.json
@@ -5,7 +5,7 @@
     "params": {
       "pagesize": "15",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "kwgg": "europe",
       "proxy": "true",

--- a/tests/modules/media_avportal_mock/responses/video-default.json
+++ b/tests/modules/media_avportal_mock/responses/video-default.json
@@ -5,7 +5,7 @@
     "params": {
       "pagesize": "15",
       "index": "1",
-      "hasmedia": "1",
+      "hasMedia": "1",
       "fl": "type,ref,doc_ref,titles_json,duration,shootstartdate,media_json,mediaorder_json,summary_json",
       "proxy": "true",
       "serverName": "wlpc0099",


### PR DESCRIPTION
## OPENEUROPA-2716

### Description

Steps to reproduce:

Create content with featured media (Eg. News)
Click on Select Media from Featured Media 
Click on Search in Av Portal
Choose Media AV Portal Video from the drop-down and click Apply
Verify thumbnails and add a video( page 1 and page 12)
Actual result:
Some Av portal videos are not working.

Expected result:
Av Portal videos should work.
Thumbnails should be visible for each video.
### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

