### PR TITLE
OPENEUROPA-2663: Media browser - Sanitize avportal resources titles.

### DIFF
--- a/src/AvPortalResource.php
+++ b/src/AvPortalResource.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\media_avportal;
 
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Component\Utility\Xss;
 
 /**
  * Value object representing an AvPortal resource.
@@ -78,17 +79,17 @@ class AvPortalResource {
 
     $titles = $this->data['titles_json'];
     if (isset($titles[$langcode])) {
-      return $titles[$langcode];
+      return Xss::filter($titles[$langcode], []);
     }
 
     // Fallback to english if the specified langcode is not present.
     if (isset($titles['EN'])) {
-      return $titles['EN'];
+      return Xss::filter($titles['EN'], []);
     }
     // Fallback to first available title,
     // when english language is not present.
     if (count($titles) > 0 && $first_title = reset($titles)) {
-      return is_string($first_title) ? $first_title : NULL;
+      return is_string($first_title) ? Xss::filter($first_title, []) : NULL;
     }
 
     return NULL;

--- a/src/AvPortalResource.php
+++ b/src/AvPortalResource.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Drupal\media_avportal;
 
 use Drupal\Component\Utility\UrlHelper;
-use Drupal\Component\Utility\Xss;
 
 /**
  * Value object representing an AvPortal resource.
@@ -79,17 +78,17 @@ class AvPortalResource {
 
     $titles = $this->data['titles_json'];
     if (isset($titles[$langcode])) {
-      return Xss::filter($titles[$langcode], []);
+      return strip_tags($titles[$langcode]);
     }
 
     // Fallback to english if the specified langcode is not present.
     if (isset($titles['EN'])) {
-      return Xss::filter($titles['EN'], []);
+      return strip_tags($titles['EN']);
     }
     // Fallback to first available title,
     // when english language is not present.
     if (count($titles) > 0 && $first_title = reset($titles)) {
-      return is_string($first_title) ? Xss::filter($first_title, []) : NULL;
+      return is_string($first_title) ? strip_tags($first_title) : NULL;
     }
 
     return NULL;

--- a/tests/modules/media_avportal_mock/responses/all-default.json
+++ b/tests/modules/media_avportal_mock/responses/all-default.json
@@ -70,8 +70,8 @@
         "ref": "I-163308",
         "duration": "",
         "titles_json": {
-          "FR": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
-          "EN": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
+          "FR": " LIVE <strong>\"Subsidiarity - as a building principle of the European Union\"</strong><br> Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
+          "EN": " LIVE <strong>\"Subsidiarity - as a building principle of the European Union\"</strong><br> Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
         },
         "summary_json": {
           "FR": "  - Welcome to the political segment by Gernot BLÜMEL, Austrian Federal Minister for the EU, Arts, Culture and Media - Keynote speech by  Frans TIMMERMANS, First Vice-President of the EC in charge of Better Regulation, Inter-Institutional Relations, the Rule of Law and the Charter of Fundamental Rights, and Chairman of the Task Force on Subsidiarity, Proportionality and \"Doing Less More Efficiently\" - Interviews Melania-Gabriela CIOT, Romania Secretary of State for European Affairs at the Ministry of Foreign Affairs Karl-Heinz LAMBERTZ, President of the Committee of the Regions Markus WALLNER, Landeshauptmann of Vorarlberg",

--- a/tests/modules/media_avportal_mock/responses/resources/I-053547.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-053547.json
@@ -207,7 +207,7 @@
           }
         },
         "titles_json": {
-          "FR": "<strong>Launch</strong> of the FP7<hr>: Clip 1 \"Ensemble\""
+          "FR": "<strong>Launch</strong> of the F&P7<hr>: Clip 1 \"Ensemble\""
         },
         "summary_json": {
           "FR": "Ces deux clips ont été produits à l'occasion du lancement du 7e programme cadre pour la recherche. Le Président de la Commission européenne, José Manuel Barroso, et d'autres Européens de premier plan, assisteront à une soirée sur la recherche européenne et ses réalisations, Les festivités débuteront par un spectacle centré sur un écran géant qui permettra de mettre en lumière la science et la recherche devant le siège du Conseil de l'UE et de la Commission européenne, en présence de la presse et de 500 invités du monde scientifique et politique. Ce spectacle sera suivi par une cérémonie au cours de laquelle les prix Descartes d'excellence scientifique et de communication scientifique seront décernés en présence de M. Janez Potocnik, le commissaire européen pour la recherche, et de Mme Annette Schavan, la ministre fédérale allemande chargée de l'éducation et de la recherche.Cette manifestation est organisée à la veille du Conseil européen de printemps de 2007. Il ne s'agit pas d'une coïncidence. La recherche joue indéniablement un rôle central dans la mise en place et le maintien d'une Europe compétitive et viable. L'organisation de cet événement parallèlement au traditionnel Conseil européen de printemps faisant suite au Conseil de Lisbonne permet de donner un signal fort quant à l'importance que l'UE accorde à la recherche."

--- a/tests/modules/media_avportal_mock/responses/resources/I-053547.json
+++ b/tests/modules/media_avportal_mock/responses/resources/I-053547.json
@@ -207,7 +207,7 @@
           }
         },
         "titles_json": {
-          "FR": "Launch of the FP7: Clip 1 \"Ensemble\""
+          "FR": "<strong>Launch</strong> of the FP7<hr>: Clip 1 \"Ensemble\""
         },
         "summary_json": {
           "FR": "Ces deux clips ont été produits à l'occasion du lancement du 7e programme cadre pour la recherche. Le Président de la Commission européenne, José Manuel Barroso, et d'autres Européens de premier plan, assisteront à une soirée sur la recherche européenne et ses réalisations, Les festivités débuteront par un spectacle centré sur un écran géant qui permettra de mettre en lumière la science et la recherche devant le siège du Conseil de l'UE et de la Commission européenne, en présence de la presse et de 500 invités du monde scientifique et politique. Ce spectacle sera suivi par une cérémonie au cours de laquelle les prix Descartes d'excellence scientifique et de communication scientifique seront décernés en présence de M. Janez Potocnik, le commissaire européen pour la recherche, et de Mme Annette Schavan, la ministre fédérale allemande chargée de l'éducation et de la recherche.Cette manifestation est organisée à la veille du Conseil européen de printemps de 2007. Il ne s'agit pas d'une coïncidence. La recherche joue indéniablement un rôle central dans la mise en place et le maintien d'une Europe compétitive et viable. L'organisation de cet événement parallèlement au traditionnel Conseil européen de printemps faisant suite au Conseil de Lisbonne permet de donner un signal fort quant à l'importance que l'UE accorde à la recherche."

--- a/tests/modules/media_avportal_mock/responses/video-default.json
+++ b/tests/modules/media_avportal_mock/responses/video-default.json
@@ -70,8 +70,8 @@
         "ref": "I-163308",
         "duration": "",
         "titles_json": {
-          "FR": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
-          "EN": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
+          "FR": " LIVE <strong>\"Subsidiarity - as a building principle of the European Union\"</strong><br> Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
+          "EN": " LIVE <strong>\"Subsidiarity - as a building principle of the European Union\"</strong><br> Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
         },
         "summary_json": {
           "FR": "  - Welcome to the political segment by Gernot BLÜMEL, Austrian Federal Minister for the EU, Arts, Culture and Media - Keynote speech by  Frans TIMMERMANS, First Vice-President of the EC in charge of Better Regulation, Inter-Institutional Relations, the Rule of Law and the Charter of Fundamental Rights, and Chairman of the Task Force on Subsidiarity, Proportionality and \"Doing Less More Efficiently\" - Interviews Melania-Gabriela CIOT, Romania Secretary of State for European Affairs at the Ministry of Foreign Affairs Karl-Heinz LAMBERTZ, President of the Committee of the Regions Markus WALLNER, Landeshauptmann of Vorarlberg",

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -315,7 +315,7 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
           ],
         ],
         'expect' => [
-          'title' => 'Launch of the FP7: Clip 1 "Ensemble"',
+          'title' => 'Launch of the F&P7: Clip 1 "Ensemble"',
         ],
       ],
       'Video with no thumbnail' => [


### PR DESCRIPTION
## OPENEUROPA-2663

### Description

All titles returned from AV Portal should be sanitised before displaying in the media browser

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

