### PR TITLE
OPENEUROPA-3154: Add a max-width to avportal video formatter.

### DIFF
--- a/css/avportal_video.formatter.css
+++ b/css/avportal_video.formatter.css
@@ -1,0 +1,3 @@
+.media-avportal-content {
+  max-width: 100%;
+}

--- a/media_avportal.libraries.yml
+++ b/media_avportal.libraries.yml
@@ -1,0 +1,5 @@
+avportal_video.formatter:
+  version: VERSION
+  css:
+    component:
+      css/avportal_video.formatter.css: {}

--- a/src/Plugin/Field/FieldFormatter/AvPortalVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AvPortalVideoFormatter.php
@@ -279,6 +279,12 @@ class AvPortalVideoFormatter extends FormatterBase implements ContainerFactoryPl
         'mozallowfullscreen' => TRUE,
         'width' => $max_width,
         'height' => $max_height,
+        'class' => 'media-avportal-content',
+      ],
+      '#attached' => [
+        'library' => [
+          'media_avportal/avportal_video.formatter',
+        ],
       ],
     ];
   }

--- a/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
+++ b/tests/src/FunctionalJavascript/MediaAvPortalCreateContentTest.php
@@ -90,6 +90,10 @@ class MediaAvPortalCreateContentTest extends WebDriverTestBase {
     // Visit the new media content.
     $page->clickLink('Midday press briefing from 25/10/2018');
 
+    // Check the iframe class.
+    $iframe_class = $assert_session->elementExists('css', 'iframe')->getAttribute('class');
+    $this->assertEqual($iframe_class, 'media-avportal-content');
+
     // Check the iframe URL.
     $iframe_url = $assert_session->elementExists('css', 'iframe')->getAttribute('src');
     $this->assertContains('ec.europa.eu/avservices/play.cfm', $iframe_url);


### PR DESCRIPTION
## OPENEUROPA-3154
### Description

Add a max-width property to the avportal video formatter so it doesn't break on small screens.

### Change log

- Added: Add a css file with a max-width property for avportal the avportal video formatter
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

