### PR TITLE
EWPP-2034: Fix xdebug-handler version until phpmd 2.12 is released.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require-dev": {
         "composer/installers": "~1.5",
+        "composer/xdebug-handler": "^2.0",
         "cweagans/composer-patches": "^1.6",
         "drupal/core-composer-scaffold": "^9.2",
         "drupal/core-dev": "^9.2",
@@ -46,7 +47,8 @@
         }
     },
     "_readme": [
-        "Explicit requirement for egulias/email-validator due to https://www.drupal.org/project/drupal/issues/3061074#comment-14300579. It can be removed when Drupal core 9.2 support is droppped."
+        "Explicit requirement for egulias/email-validator due to https://www.drupal.org/project/drupal/issues/3061074#comment-14300579. It can be removed when Drupal core 9.2 support is droppped.",
+        "Requiring composer/xdebug-handler until PHPMD 2.12 is released."
     ],
     "extra": {
         "patches": {


### PR DESCRIPTION
## EWPP

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

